### PR TITLE
Getting rid of warnings / code cleanup

### DIFF
--- a/Source/DamageWorker_ZombieBite.cs
+++ b/Source/DamageWorker_ZombieBite.cs
@@ -10,10 +10,8 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000C41 RID: 3137
     public class DamageWorker_ZombieBite : DamageWorker_AddInjury
     {
-        // Token: 0x06004219 RID: 16921 RVA: 0x001E310A File Offset: 0x001E150A
         protected override BodyPartRecord ChooseHitPart(DamageInfo dinfo, Pawn pawn)
         {
             return GetRandomNotMissingNotTorsoPart(dinfo, pawn, 0);
@@ -29,8 +27,6 @@ namespace Zombiefied
             }
             return GetRandomNotMissingNotTorsoPart(dinfo, pawn, ++i);
         }
-
-        // Token: 0x0600421A RID: 16922 RVA: 0x001E312B File Offset: 0x001E152B
         protected override void ApplySpecialEffectsToPart(Pawn pawn, float totalDamage, DamageInfo dinfo, DamageWorker.DamageResult result)
         {
             bool partSkinnedOrNotSolid = (!dinfo.HitPart.def.IsSolid(dinfo.HitPart, pawn.health.hediffSet.hediffs) || dinfo.HitPart.def.IsSkinCovered(dinfo.HitPart, pawn.health.hediffSet));

--- a/Source/GenStep_Outpost_Zombies.cs
+++ b/Source/GenStep_Outpost_Zombies.cs
@@ -20,8 +20,10 @@ namespace Zombiefied
             }
            foreach(Pawn pawn in list)
             {
+                //pawn.Kill(new DamageInfo(DamageDefOf.Bite, 7000));
                 Thing zombie = GenSpawn.Spawn(ZombiefiedMod.GenerateZombieFromSource(pawn), pawn.Position, map, pawn.Rotation);
                 pawn.Destroy();
+                //ZombiefiedMod.ReanimateDeath(pawn.Corpse);
             }
         }
     }

--- a/Source/GenStep_Outpost_Zombies.cs
+++ b/Source/GenStep_Outpost_Zombies.cs
@@ -5,12 +5,9 @@ using RimWorld;
 
 namespace Zombiefied
 {
-    // Token: 0x020003D1 RID: 977
     public class GenStep_Outpost_Zombies : GenStep
     {
         public override int SeedPart => 7;
-
-        // Token: 0x06001042 RID: 4162 RVA: 0x0007BEDC File Offset: 0x0007A2DC
         public override void Generate(Map map, GenStepParams parms)
         {
            List<Pawn> list = new List<Pawn>();

--- a/Source/GenStep_Outpost_Zombies.cs
+++ b/Source/GenStep_Outpost_Zombies.cs
@@ -20,10 +20,8 @@ namespace Zombiefied
             }
            foreach(Pawn pawn in list)
             {
-                //pawn.Kill(new DamageInfo(DamageDefOf.Bite, 7000));
                 Thing zombie = GenSpawn.Spawn(ZombiefiedMod.GenerateZombieFromSource(pawn), pawn.Position, map, pawn.Rotation);
                 pawn.Destroy();
-                //ZombiefiedMod.ReanimateDeath(pawn.Corpse);
             }
         }
     }

--- a/Source/GraphicDatabaseHeadRecords_Zombiefied.cs
+++ b/Source/GraphicDatabaseHeadRecords_Zombiefied.cs
@@ -8,18 +8,14 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000E28 RID: 3624
     public static class GraphicDatabaseHeadRecords_Zombiefied
     {
-        // Token: 0x060051CF RID: 20943 RVA: 0x0025EBF4 File Offset: 0x0025CFF4
         public static void Reset()
         {
             GraphicDatabaseHeadRecords_Zombiefied.heads.Clear();
             GraphicDatabaseHeadRecords_Zombiefied.skull = null;
             GraphicDatabaseHeadRecords_Zombiefied.stump = null;
         }
-
-        // Token: 0x060051D0 RID: 20944 RVA: 0x0025EC0C File Offset: 0x0025D00C
         private static void BuildDatabaseIfNecessary()
         {
             if (GraphicDatabaseHeadRecords_Zombiefied.heads.Count > 0 && GraphicDatabaseHeadRecords_Zombiefied.skull != null && GraphicDatabaseHeadRecords_Zombiefied.stump != null)
@@ -37,29 +33,21 @@ namespace Zombiefied
             GraphicDatabaseHeadRecords_Zombiefied.skull = new GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord(GraphicDatabaseHeadRecords_Zombiefied.SkullPath);
             GraphicDatabaseHeadRecords_Zombiefied.stump = new GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord(GraphicDatabaseHeadRecords_Zombiefied.StumpPath);
         }
-
-        // Token: 0x060051D1 RID: 20945 RVA: 0x0025ECEC File Offset: 0x0025D0EC
         public static Graphic_Multi GetHeadNamed(string graphicPath, Color skinColor)
         {
             GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord HGR = new GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord(graphicPath);
             return HGR.GetGraphic(skinColor, false);
         }
-
-        // Token: 0x060051D2 RID: 20946 RVA: 0x0025ED66 File Offset: 0x0025D166
         public static Graphic_Multi GetSkull()
         {
             GraphicDatabaseHeadRecords_Zombiefied.BuildDatabaseIfNecessary();
             return GraphicDatabaseHeadRecords_Zombiefied.skull.GetGraphic(Color.white, true);
         }
-
-        // Token: 0x060051D3 RID: 20947 RVA: 0x0025ED7D File Offset: 0x0025D17D
         public static Graphic_Multi GetStump(Color skinColor)
         {
             GraphicDatabaseHeadRecords_Zombiefied.BuildDatabaseIfNecessary();
             return GraphicDatabaseHeadRecords_Zombiefied.stump.GetGraphic(skinColor, false);
         }
-
-        // Token: 0x060051D4 RID: 20948 RVA: 0x0025ED90 File Offset: 0x0025D190
         public static Graphic_Multi GetHeadRandom(Gender gender, Color skinColor, CrownType crownType)
         {
             GraphicDatabaseHeadRecords_Zombiefied.BuildDatabaseIfNecessary();
@@ -91,33 +79,18 @@ namespace Zombiefied
             Log.Error("Failed to find head for gender=" + gender + ". Defaulting...");
             return GraphicDatabaseHeadRecords_Zombiefied.heads.First<GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord>().GetGraphic(skinColor, false);
         }
-
-        // Token: 0x04003687 RID: 13959
         private static List<GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord> heads = new List<GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord>();
-
-        // Token: 0x04003688 RID: 13960
         private static GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord skull;
-
-        // Token: 0x04003689 RID: 13961
         private static GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord stump;
-
-        // Token: 0x0400368A RID: 13962
         private static readonly string[] HeadsFolderPaths = new string[]
         {
             "Things/Pawn/Humanlike/Heads/Male",
             "Things/Pawn/Humanlike/Heads/Female",
         };
-
-        // Token: 0x0400368B RID: 13963
         private static readonly string SkullPath = "Things/Pawn/Humanlike/Heads/None_Average_Skull";
-
-        // Token: 0x0400368C RID: 13964
         private static readonly string StumpPath = "Things/Pawn/Humanlike/Heads/None_Average_Stump";
-
-        // Token: 0x02000E29 RID: 3625
         private class HeadGraphicRecord
         {
-            // Token: 0x060051D6 RID: 20950 RVA: 0x0025EED8 File Offset: 0x0025D2D8
             public HeadGraphicRecord(string graphicPath)
             {
                 this.graphicPath = graphicPath;
@@ -133,12 +106,10 @@ namespace Zombiefied
                 }
                 catch (Exception)
                 {
-                    //Log.Error("Parse error with head graphic at " + graphicPath + ": " + ex.Message, false);
                     this.crownType = CrownType.Undefined;
                     this.gender = Gender.None;
                 }
             }
-            // Token: 0x060051D7 RID: 20951 RVA: 0x0025EFA0 File Offset: 0x0025D3A0
             public Graphic_Multi GetGraphic(Color color, bool dessicated = false)
             {
                 for (int i = 0; i < this.graphics.Count; i++)
@@ -153,17 +124,9 @@ namespace Zombiefied
                 this.graphics.Add(new KeyValuePair<Color, Graphic_Multi>(color, graphic_Multi));
                 return graphic_Multi;
             }
-
-            // Token: 0x0400368D RID: 13965
             public Gender gender;
-
-            // Token: 0x0400368E RID: 13966
             public CrownType crownType;
-
-            // Token: 0x0400368F RID: 13967
             public string graphicPath;
-
-            // Token: 0x04003690 RID: 13968
             private List<KeyValuePair<Color, Graphic_Multi>> graphics = new List<KeyValuePair<Color, Graphic_Multi>>();
         }
     }

--- a/Source/GraphicDatabaseHeadRecords_Zombiefied.cs
+++ b/Source/GraphicDatabaseHeadRecords_Zombiefied.cs
@@ -88,7 +88,7 @@ namespace Zombiefied
                     return headGraphicRecord2.GetGraphic(skinColor, false);
                 }
             }
-            Log.Error("Failed to find head for gender=" + gender + ". Defaulting...", false);
+            Log.Error("Failed to find head for gender=" + gender + ". Defaulting...");
             return GraphicDatabaseHeadRecords_Zombiefied.heads.First<GraphicDatabaseHeadRecords_Zombiefied.HeadGraphicRecord>().GetGraphic(skinColor, false);
         }
 
@@ -131,14 +131,13 @@ namespace Zombiefied
                     this.crownType = (CrownType)ParseHelper.FromString(array[array.Length - 2], typeof(CrownType));
                     this.gender = (Gender)ParseHelper.FromString(array[array.Length - 3], typeof(Gender));
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     //Log.Error("Parse error with head graphic at " + graphicPath + ": " + ex.Message, false);
                     this.crownType = CrownType.Undefined;
                     this.gender = Gender.None;
                 }
             }
-
             // Token: 0x060051D7 RID: 20951 RVA: 0x0025EFA0 File Offset: 0x0025D3A0
             public Graphic_Multi GetGraphic(Color color, bool dessicated = false)
             {

--- a/Source/HediffGiver_Zombiefied.cs
+++ b/Source/HediffGiver_Zombiefied.cs
@@ -11,25 +11,14 @@ namespace Zombiefied
             if (hediff is Hediff_Injury && !pawn.health.hediffSet.PartIsMissing(hediff.Part.parent) && !pawn.health.hediffSet.PartIsMissing(hediff.Part))
             {
                 Hediff_Injury injury = hediff as Hediff_Injury;
-
-                //float oldChance = injury.def.chanceToCauseNoPain;
-                //injury.def.chanceToCauseNoPain = 70000f;
-
                 injury.PostMake();
                 injury.ageTicks = 70000000;
-
-                //injury.def.chanceToCauseNoPain = oldChance;
             }
             else if (hediff is Hediff_MissingPart && !pawn.health.hediffSet.PartIsMissing(hediff.Part.parent))
             {
                 Hediff_MissingPart missing = hediff as Hediff_MissingPart;
-                //float oldChance = missing.def.chanceToCauseNoPain;
-                //missing.def.chanceToCauseNoPain = 70000f;
-
                 missing.PostMake();
                 missing.ageTicks = 70000000;
-
-                //missing.def.chanceToCauseNoPain = oldChance;
             }
             if (pawn.health.Downed && !pawn.health.InPainShock)
             {

--- a/Source/HediffGiver_Zombiefied.cs
+++ b/Source/HediffGiver_Zombiefied.cs
@@ -11,14 +11,25 @@ namespace Zombiefied
             if (hediff is Hediff_Injury && !pawn.health.hediffSet.PartIsMissing(hediff.Part.parent) && !pawn.health.hediffSet.PartIsMissing(hediff.Part))
             {
                 Hediff_Injury injury = hediff as Hediff_Injury;
+
+                //float oldChance = injury.def.chanceToCauseNoPain;
+                //injury.def.chanceToCauseNoPain = 70000f;
+
                 injury.PostMake();
                 injury.ageTicks = 70000000;
+
+                //injury.def.chanceToCauseNoPain = oldChance;
             }
             else if (hediff is Hediff_MissingPart && !pawn.health.hediffSet.PartIsMissing(hediff.Part.parent))
             {
                 Hediff_MissingPart missing = hediff as Hediff_MissingPart;
+                //float oldChance = missing.def.chanceToCauseNoPain;
+                //missing.def.chanceToCauseNoPain = 70000f;
+
                 missing.PostMake();
                 missing.ageTicks = 70000000;
+
+                //missing.def.chanceToCauseNoPain = oldChance;
             }
             if (pawn.health.Downed && !pawn.health.InPainShock)
             {

--- a/Source/HediffGiver_Zombiefied.cs
+++ b/Source/HediffGiver_Zombiefied.cs
@@ -4,10 +4,8 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000C7F RID: 3199
     public class HediffGiver_Zombiefied : HediffGiver
     {
-        // Token: 0x06004378 RID: 17272 RVA: 0x001E8A2C File Offset: 0x001E6E2C
         public override bool OnHediffAdded(Pawn pawn, Hediff hediff)
         {
             if (hediff is Hediff_Injury && !pawn.health.hediffSet.PartIsMissing(hediff.Part.parent) && !pawn.health.hediffSet.PartIsMissing(hediff.Part))

--- a/Source/IncidentWorker_ZombieHorde.cs
+++ b/Source/IncidentWorker_ZombieHorde.cs
@@ -22,6 +22,7 @@ namespace Zombiefied
 
         protected virtual bool FactionCanBeGroupSource(Faction f, Map map, bool desperate = true)
         {
+            //bool result;
             if (f.IsPlayer)
             {
                 return false;
@@ -30,6 +31,19 @@ namespace Zombiefied
             {
                 return false;
             }
+            /*
+            if (f.defeated)
+            {
+                return false;
+            }
+            if (!desperate)
+            {
+                if (!f.def.allowedArrivalTemperatureRange.Includes(map.mapTemperature.OutdoorTemp) || !f.def.allowedArrivalTemperatureRange.Includes(map.mapTemperature.SeasonalTemp))
+                {
+                    return false;
+                }
+            }
+            */
             return true;
         }
 

--- a/Source/IncidentWorker_ZombieHorde.cs
+++ b/Source/IncidentWorker_ZombieHorde.cs
@@ -94,7 +94,7 @@ namespace Zombiefied
 
             if (list.Count < 1)
             {
-                Log.Error("Got no pawns spawning raid from parms " + parms, false);
+                Log.Error("Got no pawns spawning raid from parms " + parms);
                 return false;
             }
             else

--- a/Source/IncidentWorker_ZombieHorde.cs
+++ b/Source/IncidentWorker_ZombieHorde.cs
@@ -22,7 +22,6 @@ namespace Zombiefied
 
         protected virtual bool FactionCanBeGroupSource(Faction f, Map map, bool desperate = true)
         {
-            //bool result;
             if (f.IsPlayer)
             {
                 return false;
@@ -31,19 +30,6 @@ namespace Zombiefied
             {
                 return false;
             }
-            /*
-            if (f.defeated)
-            {
-                return false;
-            }
-            if (!desperate)
-            {
-                if (!f.def.allowedArrivalTemperatureRange.Includes(map.mapTemperature.OutdoorTemp) || !f.def.allowedArrivalTemperatureRange.Includes(map.mapTemperature.SeasonalTemp))
-                {
-                    return false;
-                }
-            }
-            */
             return true;
         }
 

--- a/Source/IncidentWorker_ZombieHorde.cs
+++ b/Source/IncidentWorker_ZombieHorde.cs
@@ -8,7 +8,6 @@ using Verse.AI.Group;
 using RimWorld;
 namespace Zombiefied
 {
-    // Token: 0x02000313 RID: 787
     public class IncidentWorker_ZombieHorde : IncidentWorker
     {
         protected void ResolveRaidPoints(IncidentParms parms)
@@ -67,9 +66,6 @@ namespace Zombiefied
             }
             return result;
         }
-
-
-        // Token: 0x06000D17 RID: 3351 RVA: 0x00061114 File Offset: 0x0005F514
         protected override bool TryExecuteWorker(IncidentParms parms)
         {
             Map map = (Map)parms.target;
@@ -141,8 +137,6 @@ namespace Zombiefied
             LessonAutoActivator.TeachOpportunity(ConceptDefOf.AllowedAreas, OpportunityType.Important);
             return true;
         }
-
-        // Token: 0x04000880 RID: 2176
         private const float PointsFactor = 3f;
     }
 }

--- a/Source/IncidentWorker_ZombiePack.cs
+++ b/Source/IncidentWorker_ZombiePack.cs
@@ -52,6 +52,8 @@ namespace Zombiefied
             {
                 return false;
             }
+            
+            //List<Pawn> list = ManhunterPackIncidentUtility.GenerateAnimals(pawnKindDef, map.Tile, parms.points);
             Rot4 rot = Rot4.FromAngleFlat((map.Center - intVec).AngleFlat);
 
             Pawn reference = null;
@@ -72,6 +74,7 @@ namespace Zombiefied
                 Pawn pawn = PawnGenerator.GeneratePawn(pawnKindDef, zFaction);
                 IntVec3 loc = CellFinder.RandomClosewalkCellNear(intVec, map, 10, null);
                 pawn.apparel.DestroyAll();
+                //pawn.SetFactionDirect(zFaction);
                 
                 Pawn_Zombiefied zomb = (Pawn_Zombiefied)GenSpawn.Spawn(pawn, loc, map, rot, WipeMode.Vanish, false);
                 if (zomb != null)

--- a/Source/IncidentWorker_ZombiePack.cs
+++ b/Source/IncidentWorker_ZombiePack.cs
@@ -9,7 +9,6 @@ using RimWorld;
 
 namespace Zombiefied
 {
-    // Token: 0x02000313 RID: 787
     public class IncidentWorker_ZombiePack : IncidentWorker
     {
         protected void ResolveRaidPoints(IncidentParms parms)
@@ -28,8 +27,6 @@ namespace Zombiefied
                     where  k.defName != null && k.defName.Contains("Zombie") && k.defName != "Zombie" && (tile == -1 || Find.World.tileTemperatures.SeasonAndOutdoorTemperatureAcceptableFor(tile, k.race))
                     select k).TryRandomElementByWeight((PawnKindDef k) => 7f, out animalKind);
         }
-
-        // Token: 0x06000D17 RID: 3351 RVA: 0x00061114 File Offset: 0x0005F514
         protected override bool TryExecuteWorker(IncidentParms parms)
         {
             Faction zFaction = Faction.OfInsects;

--- a/Source/IncidentWorker_ZombiePack.cs
+++ b/Source/IncidentWorker_ZombiePack.cs
@@ -52,8 +52,6 @@ namespace Zombiefied
             {
                 return false;
             }
-            
-            //List<Pawn> list = ManhunterPackIncidentUtility.GenerateAnimals(pawnKindDef, map.Tile, parms.points);
             Rot4 rot = Rot4.FromAngleFlat((map.Center - intVec).AngleFlat);
 
             Pawn reference = null;
@@ -74,7 +72,6 @@ namespace Zombiefied
                 Pawn pawn = PawnGenerator.GeneratePawn(pawnKindDef, zFaction);
                 IntVec3 loc = CellFinder.RandomClosewalkCellNear(intVec, map, 10, null);
                 pawn.apparel.DestroyAll();
-                //pawn.SetFactionDirect(zFaction);
                 
                 Pawn_Zombiefied zomb = (Pawn_Zombiefied)GenSpawn.Spawn(pawn, loc, map, rot, WipeMode.Vanish, false);
                 if (zomb != null)

--- a/Source/JobDriver_ZombieHunt.cs
+++ b/Source/JobDriver_ZombieHunt.cs
@@ -6,7 +6,6 @@ using RimWorld;
 
 namespace Zombiefied
 {
-    // Token: 0x02000030 RID: 48
     public class JobDriver_ZombieHunt : JobDriver
     {
         private int numMeleeAttacksMade;

--- a/Source/JobDriver_ZombieMove.cs
+++ b/Source/JobDriver_ZombieMove.cs
@@ -6,7 +6,6 @@ using RimWorld;
 
 namespace Zombiefied
 {
-    // Token: 0x02000030 RID: 48
     public class JobDriver_ZombieMove : JobDriver
     {
 

--- a/Source/JobGiver_WanderZombieHerd.cs
+++ b/Source/JobGiver_WanderZombieHerd.cs
@@ -9,15 +9,12 @@ namespace Zombiefied
 {
     public class JobGiver_WanderZombieHerd : JobGiver_Wander
     {
-        //bool attracted = false;
-        //bool fired = false;
 
         public JobGiver_WanderZombieHerd()
         {
             this.maxDanger = Danger.Deadly;
             this.priority = 77777777777777f;
             this.wanderRadius = 6f;
-            //this.ticksBetweenWandersRange = new IntRange(125, 200);
         }
 
         protected override Job TryGiveJob(Pawn pawn)
@@ -30,7 +27,6 @@ namespace Zombiefied
             pawn.mindState.nextMoveOrderIsWait = !pawn.mindState.nextMoveOrderIsWait;
             if (nextMoveOrderIsWait)
             {
-                //pawn.mindState.canFleeIndividual = false;
                 return new Job(JobDefOf.Wait)
                 {
                     expiryInterval = 77
@@ -71,11 +67,8 @@ namespace Zombiefied
                             {
                                 randomCell = pawnPath.NodesReversed[pawnPath.NodesReversed.Count - wanderLength];
 
-                                
-                                return new Job(ZombiefiedMod.zombieMove, randomCell)
-                                {
-                                    //expiryInterval = 777
-                                };
+
+                                return new Job(ZombiefiedMod.zombieMove, randomCell) { };
                             }
                         }
                     }
@@ -108,10 +101,7 @@ namespace Zombiefied
                                     randomCell = pawnPath.NodesReversed[pawnPath.NodesReversed.Count - wanderLength];
 
                                     ((Pawn_Zombiefied)pawn).attracted = true;
-                                    return new Job(ZombiefiedMod.zombieMove, randomCell)
-                                    {
-                                        //expiryInterval = 777
-                                    };
+                                    return new Job(ZombiefiedMod.zombieMove, randomCell) { };
                                 }
                             }
                         }
@@ -126,7 +116,6 @@ namespace Zombiefied
                 if (exactWanderDestAttracted.IsValid)
                 {
                     Job jobAttracted = new Job(ZombiefiedMod.zombieMove, exactWanderDestAttracted);
-                    //pawn.Map.pawnDestinationReservationManager.Reserve(pawn, jobAttracted, exactWanderDestAttracted);
                     jobAttracted.locomotionUrgency = this.locomotionUrgency;
                     return jobAttracted;
                 }
@@ -138,7 +127,6 @@ namespace Zombiefied
                 {
                     foreach (Thing thing in pawn.Position.GetRegion(pawn.Map, RegionType.Set_Passable).ListerThings.AllThings)
                     {
-                        //if (vec.ContainsStaticFire(pawn.Map))
                         if (thing is Fire && ((Fire)thing).fireSize > 1.37f && (pawn.Position - thing.Position).LengthHorizontal < 3.1f)
                         {
                             ((Pawn_Zombiefied)pawn).fired = true;
@@ -160,7 +148,6 @@ namespace Zombiefied
                 return null;
             }
             Job job = new Job(ZombiefiedMod.zombieMove, exactWanderDest);
-            //pawn.Map.pawnDestinationReservationManager.Reserve(pawn, job, exactWanderDest);
             job.locomotionUrgency = this.locomotionUrgency;
             return job;
         }
@@ -168,11 +155,7 @@ namespace Zombiefied
         protected override IntVec3 GetExactWanderDest(Pawn pawn)
         {
             IntVec3 wanderRoot = this.GetWanderRoot(pawn);
-            //pawn.Map.
-            //wanderDestValidator = Validator;
             return RCellFinder.RandomWanderDestFor(pawn, wanderRoot, this.wanderRadius, this.wanderDestValidator, Danger.Deadly);
-            //return RCellFinder.RandomWanderDestFor(pawn, wanderRoot, this.wanderRadius, Validator, Danger.Deadly);
-            //return CellFinder.RandomClosewalkCellNear(wanderRoot, pawn.Map, (int)this.wanderRadius);
         }
 
         private bool Validator(Pawn pawn, IntVec3 vec0, IntVec3 vec1)
@@ -197,7 +180,6 @@ namespace Zombiefied
             }
 
             List<Pawn> allPawnsSpawned = pawn.Map.mapPawns.AllPawnsSpawned;
-            //List<Thing> allThingsRegion = pawn.GetRegion().ListerThings.AllThings;
 
             Pawn pawnToReturn = null;
             float num = 0f;
@@ -206,7 +188,6 @@ namespace Zombiefied
             bool closeToEdge = pawn.distanceToEdge < Rand.RangeSeeded(17, 57, Find.TickManager.TicksAbs + pawn.thingIDNumber);
 
             for (int i = 0; i < allPawnsSpawned.Count; i++)
-            //for (int i = 0; i < allThingsRegion.Count; i++)
             {
                 Pawn_Zombiefied pawn2 = allPawnsSpawned[i] as Pawn_Zombiefied;
                 if (pawn2 != null && pawn != pawn2)

--- a/Source/JobGiver_WanderZombieHerd.cs
+++ b/Source/JobGiver_WanderZombieHerd.cs
@@ -7,13 +7,11 @@ using Verse.AI;
 
 namespace Zombiefied
 {
-    // Token: 0x02000A34 RID: 2612
     public class JobGiver_WanderZombieHerd : JobGiver_Wander
     {
         //bool attracted = false;
         //bool fired = false;
 
-        // Token: 0x0600377A RID: 14202 RVA: 0x0019834C File Offset: 0x0019674C
         public JobGiver_WanderZombieHerd()
         {
             this.maxDanger = Danger.Deadly;
@@ -181,8 +179,6 @@ namespace Zombiefied
         {
             return vec0.ContainsStaticFire(pawn.Map) && !pawn.IsBurning();
         }
-
-        // Token: 0x0600377B RID: 14203 RVA: 0x00198374 File Offset: 0x00196774
         protected override IntVec3 GetWanderRoot(Pawn pawn)
         {
             Pawn pawn2 = BestPawnToWander(pawn as Pawn_Zombiefied);

--- a/Source/JobGiver_WanderZombieHerd.cs
+++ b/Source/JobGiver_WanderZombieHerd.cs
@@ -9,12 +9,15 @@ namespace Zombiefied
 {
     public class JobGiver_WanderZombieHerd : JobGiver_Wander
     {
+        //bool attracted = false;
+        //bool fired = false;
 
         public JobGiver_WanderZombieHerd()
         {
             this.maxDanger = Danger.Deadly;
             this.priority = 77777777777777f;
             this.wanderRadius = 6f;
+            //this.ticksBetweenWandersRange = new IntRange(125, 200);
         }
 
         protected override Job TryGiveJob(Pawn pawn)
@@ -27,6 +30,7 @@ namespace Zombiefied
             pawn.mindState.nextMoveOrderIsWait = !pawn.mindState.nextMoveOrderIsWait;
             if (nextMoveOrderIsWait)
             {
+                //pawn.mindState.canFleeIndividual = false;
                 return new Job(JobDefOf.Wait)
                 {
                     expiryInterval = 77
@@ -67,8 +71,11 @@ namespace Zombiefied
                             {
                                 randomCell = pawnPath.NodesReversed[pawnPath.NodesReversed.Count - wanderLength];
 
-
-                                return new Job(ZombiefiedMod.zombieMove, randomCell) { };
+                                
+                                return new Job(ZombiefiedMod.zombieMove, randomCell)
+                                {
+                                    //expiryInterval = 777
+                                };
                             }
                         }
                     }
@@ -101,7 +108,10 @@ namespace Zombiefied
                                     randomCell = pawnPath.NodesReversed[pawnPath.NodesReversed.Count - wanderLength];
 
                                     ((Pawn_Zombiefied)pawn).attracted = true;
-                                    return new Job(ZombiefiedMod.zombieMove, randomCell) { };
+                                    return new Job(ZombiefiedMod.zombieMove, randomCell)
+                                    {
+                                        //expiryInterval = 777
+                                    };
                                 }
                             }
                         }
@@ -116,6 +126,7 @@ namespace Zombiefied
                 if (exactWanderDestAttracted.IsValid)
                 {
                     Job jobAttracted = new Job(ZombiefiedMod.zombieMove, exactWanderDestAttracted);
+                    //pawn.Map.pawnDestinationReservationManager.Reserve(pawn, jobAttracted, exactWanderDestAttracted);
                     jobAttracted.locomotionUrgency = this.locomotionUrgency;
                     return jobAttracted;
                 }
@@ -127,6 +138,7 @@ namespace Zombiefied
                 {
                     foreach (Thing thing in pawn.Position.GetRegion(pawn.Map, RegionType.Set_Passable).ListerThings.AllThings)
                     {
+                        //if (vec.ContainsStaticFire(pawn.Map))
                         if (thing is Fire && ((Fire)thing).fireSize > 1.37f && (pawn.Position - thing.Position).LengthHorizontal < 3.1f)
                         {
                             ((Pawn_Zombiefied)pawn).fired = true;
@@ -148,6 +160,7 @@ namespace Zombiefied
                 return null;
             }
             Job job = new Job(ZombiefiedMod.zombieMove, exactWanderDest);
+            //pawn.Map.pawnDestinationReservationManager.Reserve(pawn, job, exactWanderDest);
             job.locomotionUrgency = this.locomotionUrgency;
             return job;
         }
@@ -155,7 +168,11 @@ namespace Zombiefied
         protected override IntVec3 GetExactWanderDest(Pawn pawn)
         {
             IntVec3 wanderRoot = this.GetWanderRoot(pawn);
+            //pawn.Map.
+            //wanderDestValidator = Validator;
             return RCellFinder.RandomWanderDestFor(pawn, wanderRoot, this.wanderRadius, this.wanderDestValidator, Danger.Deadly);
+            //return RCellFinder.RandomWanderDestFor(pawn, wanderRoot, this.wanderRadius, Validator, Danger.Deadly);
+            //return CellFinder.RandomClosewalkCellNear(wanderRoot, pawn.Map, (int)this.wanderRadius);
         }
 
         private bool Validator(Pawn pawn, IntVec3 vec0, IntVec3 vec1)
@@ -180,6 +197,7 @@ namespace Zombiefied
             }
 
             List<Pawn> allPawnsSpawned = pawn.Map.mapPawns.AllPawnsSpawned;
+            //List<Thing> allThingsRegion = pawn.GetRegion().ListerThings.AllThings;
 
             Pawn pawnToReturn = null;
             float num = 0f;
@@ -188,6 +206,7 @@ namespace Zombiefied
             bool closeToEdge = pawn.distanceToEdge < Rand.RangeSeeded(17, 57, Find.TickManager.TicksAbs + pawn.thingIDNumber);
 
             for (int i = 0; i < allPawnsSpawned.Count; i++)
+            //for (int i = 0; i < allThingsRegion.Count; i++)
             {
                 Pawn_Zombiefied pawn2 = allPawnsSpawned[i] as Pawn_Zombiefied;
                 if (pawn2 != null && pawn != pawn2)

--- a/Source/JobGiver_ZombieResponse.cs
+++ b/Source/JobGiver_ZombieResponse.cs
@@ -7,16 +7,12 @@ using RimWorld;
 
 namespace Zombiefied
 {
-    // Token: 0x020000A4 RID: 164
     public class JobGiver_ZombieResponse : ThinkNode_JobGiver
     {
-        // Token: 0x060003E6 RID: 998 RVA: 0x0002923C File Offset: 0x0002763C
         protected override Job TryGiveJob(Pawn pawn)
         {
             return this.TryGetAttackNearbyEnemyJob(pawn);
         }
-
-        // Token: 0x060003E7 RID: 999 RVA: 0x000292AC File Offset: 0x000276AC
         private Job TryGetAttackNearbyEnemyJob(Pawn pawn)
         {
             Pawn thing = BestPawnToHuntForPredator(pawn);

--- a/Source/JobGiver_ZombieResponse.cs
+++ b/Source/JobGiver_ZombieResponse.cs
@@ -30,11 +30,13 @@ namespace Zombiefied
 
         public Pawn BestPawnToHuntForPredator(Pawn predator, float range = 7f)
         {
+            //List<Pawn> allPawnsSpawned = predator.Map.mapPawns.AllPawnsSpawned;
             List<Thing> allThingsRegion = predator.GetRegion().ListerThings.AllThings;
 
             Pawn pawnToReturn = null;
             float num = 0f;
 
+            //for (int i = 0; i < allPawnsSpawned.Count; i++)
             for (int i = 0; i < allThingsRegion.Count; i++)
                 {
                 Pawn pawn2 = allThingsRegion[i] as Pawn;

--- a/Source/JobGiver_ZombieResponse.cs
+++ b/Source/JobGiver_ZombieResponse.cs
@@ -30,13 +30,11 @@ namespace Zombiefied
 
         public Pawn BestPawnToHuntForPredator(Pawn predator, float range = 7f)
         {
-            //List<Pawn> allPawnsSpawned = predator.Map.mapPawns.AllPawnsSpawned;
             List<Thing> allThingsRegion = predator.GetRegion().ListerThings.AllThings;
 
             Pawn pawnToReturn = null;
             float num = 0f;
 
-            //for (int i = 0; i < allPawnsSpawned.Count; i++)
             for (int i = 0; i < allThingsRegion.Count; i++)
                 {
                 Pawn pawn2 = allThingsRegion[i] as Pawn;

--- a/Source/PawnRenderer_Zombiefied.cs
+++ b/Source/PawnRenderer_Zombiefied.cs
@@ -6,10 +6,8 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000C3D RID: 3133
     public class PawnRenderer_Zombiefied
     {
-        // Token: 0x060041F0 RID: 16880 RVA: 0x001E11B8 File Offset: 0x001DF5B8
         public PawnRenderer_Zombiefied(Pawn pawn, ZombieData data)
         {
             //this.oldPawn = oldPawn;
@@ -21,9 +19,6 @@ namespace Zombiefied
             //this.graphics = gra;
             //this.effecters = new PawnStatusEffecters(pawn);
         }
-
-        // Token: 0x17000A40 RID: 2624
-        // (get) Token: 0x060041F1 RID: 16881 RVA: 0x001E120E File Offset: 0x001DF60E
         private RotDrawMode CurRotDrawMode
         {
             get
@@ -35,14 +30,10 @@ namespace Zombiefied
                 return RotDrawMode.Fresh;
             }
         }
-
-        // Token: 0x060041F2 RID: 16882 RVA: 0x001E1242 File Offset: 0x001DF642
         public void RenderPawnAt(Vector3 drawLoc)
         {
             this.RenderPawnAt(drawLoc, this.CurRotDrawMode, !this.pawn.health.hediffSet.HasHead);
         }
-
-        // Token: 0x060041F3 RID: 16883 RVA: 0x001E126C File Offset: 0x001DF66C
         public void RenderPawnAt(Vector3 drawLoc, RotDrawMode bodyDrawType, bool headStump)
         {
             if (!this.graphics.AllResolved)
@@ -143,8 +134,6 @@ namespace Zombiefied
             }
             this.DrawDebug();
         }
-
-        // Token: 0x060041F4 RID: 16884 RVA: 0x001E1690 File Offset: 0x001DFA90
         public void RenderPortait()
         {
             Vector3 zero = Vector3.zero;
@@ -161,14 +150,10 @@ namespace Zombiefied
             }
             this.RenderPawnInternal(zero, quat, true, Rot4.South, Rot4.South, this.CurRotDrawMode, true, !this.pawn.health.hediffSet.HasHead);
         }
-
-        // Token: 0x060041F5 RID: 16885 RVA: 0x001E173C File Offset: 0x001DFB3C
         private void RenderPawnInternal(Vector3 rootLoc, Quaternion quat, bool renderBody, RotDrawMode draw, bool headStump)
         {
             this.RenderPawnInternal(rootLoc, quat, renderBody, this.pawn.Rotation, this.pawn.Rotation, draw, false, headStump);
         }
-
-        // Token: 0x060041F6 RID: 16886 RVA: 0x001E1770 File Offset: 0x001DFB70
         private void RenderPawnInternal(Vector3 rootLoc, Quaternion quat, bool renderBody, Rot4 bodyFacing, Rot4 headFacing, RotDrawMode bodyDrawType, bool portrait, bool headStump)
         {
             if (!this.graphics.AllResolved)
@@ -297,8 +282,6 @@ namespace Zombiefied
                 this.statusOverlays.RenderStatusOverlays(bodyLoc, quat, MeshPool.humanlikeHeadSet.MeshAt(headFacing));
             }
         }
-
-        // Token: 0x060041F7 RID: 16887 RVA: 0x001E1CE8 File Offset: 0x001E00E8
         private void DrawEquipment(Vector3 rootLoc)
         {
             if (this.pawn.Dead || !this.pawn.Spawned)
@@ -362,8 +345,6 @@ namespace Zombiefied
                 }
             }
         }
-
-        // Token: 0x060041F8 RID: 16888 RVA: 0x001E2014 File Offset: 0x001E0414
         public void DrawEquipmentAiming(Thing eq, Vector3 drawLoc, float aimAngle)
         {
             float num = aimAngle - 90f;
@@ -397,14 +378,10 @@ namespace Zombiefied
             }
             Graphics.DrawMesh(mesh, drawLoc, Quaternion.AngleAxis(num, Vector3.up), matSingle, 0);
         }
-
-        // Token: 0x060041F9 RID: 16889 RVA: 0x001E20FC File Offset: 0x001E04FC
         private bool CarryWeaponOpenly()
         {
             return (this.pawn.carryTracker == null || this.pawn.carryTracker.CarriedThing == null) && (this.pawn.Drafted || (this.pawn.CurJob != null && this.pawn.CurJob.def.alwaysShowWeapon) || (this.pawn.mindState.duty != null && this.pawn.mindState.duty.def.alwaysShowWeapon));
         }
-
-        // Token: 0x060041FA RID: 16890 RVA: 0x001E21A8 File Offset: 0x001E05A8
         private Rot4 LayingFacing()
         {
             if (this.pawn.GetPosture() == PawnPosture.LayingOnGroundFaceUp)
@@ -424,8 +401,6 @@ namespace Zombiefied
             }
             return Rot4.East;
         }
-
-        // Token: 0x060041FB RID: 16891 RVA: 0x001E2270 File Offset: 0x001E0670
         public Vector3 BaseHeadOffsetAt(Rot4 rotation)
         {
             float num = PawnRenderer_Zombiefied.HorHeadOffsets[(int)graphics.data.bodyType.index];
@@ -444,22 +419,14 @@ namespace Zombiefied
                     return Vector3.zero;
             }
         }
-
-        // Token: 0x060041FC RID: 16892 RVA: 0x001E231E File Offset: 0x001E071E
         public void Notify_DamageApplied(DamageInfo dam)
         {
-            //this.graphics.flasher.Notify_DamageApplied(dam);
             this.wiggler.Notify_DamageApplied(dam);
         }
-
-        // Token: 0x060041FD RID: 16893 RVA: 0x001E233D File Offset: 0x001E073D
         public void RendererTick()
         {
             this.wiggler.WigglerTick();
-            //this.effecters.EffectersTick();
         }
-
-        // Token: 0x060041FE RID: 16894 RVA: 0x001E2358 File Offset: 0x001E0758
         private void DrawDebug()
         {
             if (DebugViewSettings.drawDuties && Find.Selector.IsSelected(this.pawn) && this.pawn.mindState != null && this.pawn.mindState.duty != null)
@@ -467,76 +434,27 @@ namespace Zombiefied
                 //this.pawn.mindState.duty.DrawDebug(this.pawn);
             }
         }
-
-        //private Pawn oldPawn;
-
-        // Token: 0x04002DCF RID: 11727
         private Pawn pawn;
-
-        // Token: 0x04002DD0 RID: 11728
         public ZombieGraphicSet graphics;
-
-        // Token: 0x04002DD1 RID: 11729
         public PawnDownedWiggler wiggler;
-
-        // Token: 0x04002DD2 RID: 11730
         private PawnHeadOverlays statusOverlays;
-
-        // Token: 0x04002DD3 RID: 11731
-        //private PawnStatusEffecters effecters;
-
-        // Token: 0x04002DD4 RID: 11732
         private PawnWoundDrawer woundOverlays;
-
-        // Token: 0x04002DD5 RID: 11733
         private Graphic_Shadow shadowGraphic;
-
-        // Token: 0x04002DD6 RID: 11734
         private const float CarriedThingDrawAngle = 16f;
-
-        // Token: 0x04002DD7 RID: 11735
         private const float SubInterval = 0.00390625f;
-
-        // Token: 0x04002DD8 RID: 11736
         private const float YOffset_PrimaryEquipmentUnder = 0f;
-
-        // Token: 0x04002DD9 RID: 11737
         private const float YOffset_Behind = 0.00390625f;
-
-        // Token: 0x04002DDA RID: 11738
         private const float YOffset_Body = 0.0078125f;
-
-        // Token: 0x04002DDB RID: 11739
         private const float YOffsetInterval_Clothes = 0.00390625f;
-
-        // Token: 0x04002DDC RID: 11740
         private const float YOffset_Wounds = 0.01953125f;
-
-        // Token: 0x04002DDD RID: 11741
         private const float YOffset_Shell = 0.0234375f;
-
-        // Token: 0x04002DDE RID: 11742
         private const float YOffset_Head = 0.02734375f;
-
-        // Token: 0x04002DDF RID: 11743
         private const float YOffset_OnHead = 0.03125f;
-
-        // Token: 0x04002DE0 RID: 11744
         private const float YOffset_PostHead = 0.03515625f;
-
-        // Token: 0x04002DE1 RID: 11745
         private const float YOffset_CarriedThing = 0.0390625f;
-
-        // Token: 0x04002DE2 RID: 11746
         private const float YOffset_PrimaryEquipmentOver = 0.0390625f;
-
-        // Token: 0x04002DE3 RID: 11747
         private const float YOffset_Status = 0.04296875f;
-
-        // Token: 0x04002DE4 RID: 11748
         private const float UpHeadOffset = 0.34f;
-
-        // Token: 0x04002DE5 RID: 11749
         private static readonly float[] HorHeadOffsets = new float[]
         {
             0f,

--- a/Source/PawnRenderer_Zombiefied.cs
+++ b/Source/PawnRenderer_Zombiefied.cs
@@ -129,26 +129,9 @@ namespace Zombiefied
                     {
                         quat = Quaternion.AngleAxis(this.wiggler.downedAngle, Vector3.up);
                     }
-                    else if (true)
-                    {
-                        quat = rot.AsQuat;
-                    }
                     else
                     {
-                        Rot4 rot2 = Rot4.West;
-                        int num = this.pawn.thingIDNumber % 2;
-                        if (num != 0)
-                        {
-                            if (num == 1)
-                            {
-                                rot2 = Rot4.East;
-                            }
-                        }
-                        else
-                        {
-                            rot2 = Rot4.West;
-                        }
-                        quat = rot2.AsQuat;
+                        quat = rot.AsQuat;
                     }
                 }
                 this.RenderPawnInternal(rootLoc, quat, renderBody, rot, rot, bodyDrawType, false, headStump);
@@ -203,14 +186,7 @@ namespace Zombiefied
                 }
                 else
                 {
-                    if (true)
-                    {
-                        mesh = MeshPool.humanlikeBodySet.MeshAt(bodyFacing);
-                    }
-                    else
-                    {
-                        mesh = this.graphics.nakedGraphic.MeshAt(bodyFacing);
-                    }
+                    mesh = MeshPool.humanlikeBodySet.MeshAt(bodyFacing);
                     List<Material> list = this.graphics.MatsBodyBaseAt(bodyFacing, bodyDrawType);
                     for (int i = 0; i < list.Count; i++)
                     {
@@ -435,33 +411,16 @@ namespace Zombiefied
             {
                 return Rot4.South;
             }
-            if (true)
+            switch (this.pawn.thingIDNumber % 4)
             {
-                switch (this.pawn.thingIDNumber % 4)
-                {
-                    case 0:
-                        return Rot4.South;
-                    case 1:
-                        return Rot4.South;
-                    case 2:
-                        return Rot4.East;
-                    case 3:
-                        return Rot4.West;
-                }
-            }
-            else
-            {
-                switch (this.pawn.thingIDNumber % 4)
-                {
-                    case 0:
-                        return Rot4.South;
-                    case 1:
-                        return Rot4.East;
-                    case 2:
-                        return Rot4.West;
-                    case 3:
-                        return Rot4.West;
-                }
+                case 0:
+                    return Rot4.South;
+                case 1:
+                    return Rot4.South;
+                case 2:
+                    return Rot4.East;
+                case 3:
+                    return Rot4.West;
             }
             return Rot4.East;
         }

--- a/Source/PawnRenderer_Zombiefied.cs
+++ b/Source/PawnRenderer_Zombiefied.cs
@@ -10,11 +10,14 @@ namespace Zombiefied
     {
         public PawnRenderer_Zombiefied(Pawn pawn, ZombieData data)
         {
+            //this.oldPawn = oldPawn;
             this.pawn = pawn;
             this.wiggler = new PawnDownedWiggler(pawn);
             this.statusOverlays = new PawnHeadOverlays(pawn);
             this.woundOverlays = new PawnWoundDrawer(pawn);
             this.graphics = new ZombieGraphicSet(data);
+            //this.graphics = gra;
+            //this.effecters = new PawnStatusEffecters(pawn);
         }
         private RotDrawMode CurRotDrawMode
         {
@@ -172,6 +175,7 @@ namespace Zombiefied
                     List<Material> list = this.graphics.MatsBodyBaseAt(bodyFacing, bodyDrawType);
                     for (int i = 0; i < list.Count; i++)
                     {
+                        //Material damagedMat = this.graphics.flasher.GetDamagedMat(list[i]);
                         GenDraw.DrawMeshNowOrLater(mesh, loc, quat, list[i], portrait);
                         loc.y += 0.00390625f;
                     }
@@ -198,6 +202,7 @@ namespace Zombiefied
             if (this.graphics.headGraphic != null)
             {
                 Vector3 b = quat * this.BaseHeadOffsetAt(headFacing);
+                //b = new Vector3(b.x, 0f, b.y);
                 Material material = this.graphics.HeadMatAt(headFacing, bodyDrawType, headStump);
                 if (material != null)
                 {
@@ -219,11 +224,13 @@ namespace Zombiefied
                             {
                                 flag = true;
                                 Material material2 = apparelGraphics[j].graphic.MatAt(bodyFacing, null);
+                                //material2 = this.graphics.flasher.GetDamagedMat(material2);
                                 GenDraw.DrawMeshNowOrLater(mesh3, loc2, quat, material2, portrait);
                             }
                             else
                             {
                                 Material material3 = apparelGraphics[j].graphic.MatAt(bodyFacing, null);
+                                //material3 = this.graphics.flasher.GetDamagedMat(material3);
                                 Vector3 loc3 = rootLoc + b;
                                 loc3.y += ((!(bodyFacing == Rot4.North)) ? 0.03515625f : 0.00390625f);
                                 GenDraw.DrawMeshNowOrLater(mesh3, loc3, quat, material3, portrait);
@@ -246,13 +253,30 @@ namespace Zombiefied
                     if (apparelGraphicRecord.sourceApparel.def.apparel.LastLayer == ApparelLayerDefOf.Shell)
                     {
                         Material material4 = apparelGraphicRecord.graphic.MatAt(bodyFacing, null);
+                        //material4 = this.graphics.flasher.GetDamagedMat(material4);
                         GenDraw.DrawMeshNowOrLater(mesh, vector, quat, material4, portrait);
                     }
                 }
             }
+            /*
+            if (!portrait && this.oldPawn.RaceProps.Animal && this.oldPawn.inventory != null && this.oldPawn.inventory.innerContainer.Count > 0) && this.graphics.packGraphic != null)
+            {
+                Graphics.DrawMesh(mesh, vector, quat, this.graphics.packGraphic.MatAt(bodyFacing, null), 0);
+            }
+            */
             if (!portrait)
             {
                 this.DrawEquipment(rootLoc);
+                /*
+                if (this.oldPawn.apparel != null)
+                {
+                    List<Apparel> wornApparel = this.oldPawn.apparel.WornApparel;
+                    for (int l = 0; l < wornApparel.Count; l++)
+                    {
+                        wornApparel[l].DrawWornExtras();
+                    }
+                }
+                */
                 Vector3 bodyLoc = rootLoc;
                 bodyLoc.y += 0.04296875f;
                 this.statusOverlays.RenderStatusOverlays(bodyLoc, quat, MeshPool.humanlikeHeadSet.MeshAt(headFacing));
@@ -304,6 +328,7 @@ namespace Zombiefied
                 else if (this.pawn.Rotation == Rot4.North)
                 {
                     Vector3 drawLoc3 = rootLoc + new Vector3(0f, 0f, -0.11f);
+                    //drawLoc3.y = drawLoc3.y;
                     this.DrawEquipmentAiming(this.pawn.equipment.Primary, drawLoc3, 143f);
                 }
                 else if (this.pawn.Rotation == Rot4.East)
@@ -406,8 +431,6 @@ namespace Zombiefied
         {
             if (DebugViewSettings.drawDuties && Find.Selector.IsSelected(this.pawn) && this.pawn.mindState != null && this.pawn.mindState.duty != null)
             {
-                // Well, we should probably do some kind of DrawDebug at some point, right?
-                // TODO: Figure out this
                 //this.pawn.mindState.duty.DrawDebug(this.pawn);
             }
         }

--- a/Source/PawnRenderer_Zombiefied.cs
+++ b/Source/PawnRenderer_Zombiefied.cs
@@ -10,14 +10,11 @@ namespace Zombiefied
     {
         public PawnRenderer_Zombiefied(Pawn pawn, ZombieData data)
         {
-            //this.oldPawn = oldPawn;
             this.pawn = pawn;
             this.wiggler = new PawnDownedWiggler(pawn);
             this.statusOverlays = new PawnHeadOverlays(pawn);
             this.woundOverlays = new PawnWoundDrawer(pawn);
             this.graphics = new ZombieGraphicSet(data);
-            //this.graphics = gra;
-            //this.effecters = new PawnStatusEffecters(pawn);
         }
         private RotDrawMode CurRotDrawMode
         {
@@ -175,7 +172,6 @@ namespace Zombiefied
                     List<Material> list = this.graphics.MatsBodyBaseAt(bodyFacing, bodyDrawType);
                     for (int i = 0; i < list.Count; i++)
                     {
-                        //Material damagedMat = this.graphics.flasher.GetDamagedMat(list[i]);
                         GenDraw.DrawMeshNowOrLater(mesh, loc, quat, list[i], portrait);
                         loc.y += 0.00390625f;
                     }
@@ -202,7 +198,6 @@ namespace Zombiefied
             if (this.graphics.headGraphic != null)
             {
                 Vector3 b = quat * this.BaseHeadOffsetAt(headFacing);
-                //b = new Vector3(b.x, 0f, b.y);
                 Material material = this.graphics.HeadMatAt(headFacing, bodyDrawType, headStump);
                 if (material != null)
                 {
@@ -224,13 +219,11 @@ namespace Zombiefied
                             {
                                 flag = true;
                                 Material material2 = apparelGraphics[j].graphic.MatAt(bodyFacing, null);
-                                //material2 = this.graphics.flasher.GetDamagedMat(material2);
                                 GenDraw.DrawMeshNowOrLater(mesh3, loc2, quat, material2, portrait);
                             }
                             else
                             {
                                 Material material3 = apparelGraphics[j].graphic.MatAt(bodyFacing, null);
-                                //material3 = this.graphics.flasher.GetDamagedMat(material3);
                                 Vector3 loc3 = rootLoc + b;
                                 loc3.y += ((!(bodyFacing == Rot4.North)) ? 0.03515625f : 0.00390625f);
                                 GenDraw.DrawMeshNowOrLater(mesh3, loc3, quat, material3, portrait);
@@ -253,30 +246,13 @@ namespace Zombiefied
                     if (apparelGraphicRecord.sourceApparel.def.apparel.LastLayer == ApparelLayerDefOf.Shell)
                     {
                         Material material4 = apparelGraphicRecord.graphic.MatAt(bodyFacing, null);
-                        //material4 = this.graphics.flasher.GetDamagedMat(material4);
                         GenDraw.DrawMeshNowOrLater(mesh, vector, quat, material4, portrait);
                     }
                 }
             }
-            /*
-            if (!portrait && this.oldPawn.RaceProps.Animal && this.oldPawn.inventory != null && this.oldPawn.inventory.innerContainer.Count > 0) && this.graphics.packGraphic != null)
-            {
-                Graphics.DrawMesh(mesh, vector, quat, this.graphics.packGraphic.MatAt(bodyFacing, null), 0);
-            }
-            */
             if (!portrait)
             {
                 this.DrawEquipment(rootLoc);
-                /*
-                if (this.oldPawn.apparel != null)
-                {
-                    List<Apparel> wornApparel = this.oldPawn.apparel.WornApparel;
-                    for (int l = 0; l < wornApparel.Count; l++)
-                    {
-                        wornApparel[l].DrawWornExtras();
-                    }
-                }
-                */
                 Vector3 bodyLoc = rootLoc;
                 bodyLoc.y += 0.04296875f;
                 this.statusOverlays.RenderStatusOverlays(bodyLoc, quat, MeshPool.humanlikeHeadSet.MeshAt(headFacing));
@@ -328,7 +304,6 @@ namespace Zombiefied
                 else if (this.pawn.Rotation == Rot4.North)
                 {
                     Vector3 drawLoc3 = rootLoc + new Vector3(0f, 0f, -0.11f);
-                    //drawLoc3.y = drawLoc3.y;
                     this.DrawEquipmentAiming(this.pawn.equipment.Primary, drawLoc3, 143f);
                 }
                 else if (this.pawn.Rotation == Rot4.East)
@@ -431,6 +406,8 @@ namespace Zombiefied
         {
             if (DebugViewSettings.drawDuties && Find.Selector.IsSelected(this.pawn) && this.pawn.mindState != null && this.pawn.mindState.duty != null)
             {
+                // Well, we should probably do some kind of DrawDebug at some point, right?
+                // TODO: Figure out this
                 //this.pawn.mindState.duty.DrawDebug(this.pawn);
             }
         }

--- a/Source/Pawn_DrawTracker_Zombiefied.cs
+++ b/Source/Pawn_DrawTracker_Zombiefied.cs
@@ -5,10 +5,8 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000C35 RID: 3125
     public class Pawn_DrawTracker_Zombiefied
     {
-        // Token: 0x060041CE RID: 16846 RVA: 0x001E04F8 File Offset: 0x001DE8F8
         public Pawn_DrawTracker_Zombiefied(Pawn pawn, ZombieData data)
         {
             this.pawn = pawn;
@@ -20,9 +18,6 @@ namespace Zombiefied
             this.footprintMaker = new PawnFootprintMaker(pawn);
             this.breathMoteMaker = new PawnBreathMoteMaker(pawn);
         }
-
-        // Token: 0x17000A39 RID: 2617
-        // (get) Token: 0x060041CF RID: 16847 RVA: 0x001E0568 File Offset: 0x001DE968
         public Vector3 DrawPos
         {
             get
@@ -35,8 +30,6 @@ namespace Zombiefied
                 return vector;
             }
         }
-
-        // Token: 0x060041D0 RID: 16848 RVA: 0x001E05C8 File Offset: 0x001DE9C8
         public void DrawTrackerTick()
         {
             if (!this.pawn.Spawned)
@@ -53,26 +46,18 @@ namespace Zombiefied
             this.leaner.LeanerTick();
             this.renderer.RendererTick();
         }
-
-        // Token: 0x060041D1 RID: 16849 RVA: 0x001E0654 File Offset: 0x001DEA54
         public void DrawAt(Vector3 loc)
         {
             this.renderer.RenderPawnAt(loc);
         }
-
-        // Token: 0x060041D2 RID: 16850 RVA: 0x001E0662 File Offset: 0x001DEA62
         public void Notify_Spawned()
         {
             this.tweener.ResetTweenedPosToRoot();
         }
-
-        // Token: 0x060041D3 RID: 16851 RVA: 0x001E066F File Offset: 0x001DEA6F
         public void Notify_WarmingCastAlongLine(ShootLine newShootLine, IntVec3 ShootPosition)
         {
             this.leaner.Notify_WarmingCastAlongLine(newShootLine, ShootPosition);
         }
-
-        // Token: 0x060041D4 RID: 16852 RVA: 0x001E067E File Offset: 0x001DEA7E
         public void Notify_DamageApplied(DamageInfo dinfo)
         {
             if (this.pawn.Destroyed)
@@ -82,8 +67,6 @@ namespace Zombiefied
             this.jitterer.Notify_DamageApplied(dinfo);
             this.renderer.Notify_DamageApplied(dinfo);
         }
-
-        // Token: 0x060041D5 RID: 16853 RVA: 0x001E06AC File Offset: 0x001DEAAC
         public void Notify_MeleeAttackOn(Thing Target)
         {
             if (Target.Position != this.pawn.Position)
@@ -95,8 +78,6 @@ namespace Zombiefied
                 this.jitterer.AddOffset(0.25f, (Target.DrawPos - this.pawn.DrawPos).AngleFlat());
             }
         }
-
-        // Token: 0x060041D6 RID: 16854 RVA: 0x001E0750 File Offset: 0x001DEB50
         public void Notify_DebugAffected()
         {
             for (int i = 0; i < 10; i++)
@@ -105,32 +86,14 @@ namespace Zombiefied
             }
             this.jitterer.AddOffset(0.05f, (float)Rand.RangeSeeded(0, 360, Find.TickManager.TicksAbs));
         }
-
-        // Token: 0x04002DA2 RID: 11682
         private Pawn pawn;
-
-        // Token: 0x04002DA3 RID: 11683
         public PawnTweener tweener;
-
-        // Token: 0x04002DA4 RID: 11684
         private JitterHandler jitterer;
-
-        // Token: 0x04002DA5 RID: 11685
         public PawnLeaner leaner;
-
-        // Token: 0x04002DA6 RID: 11686
         public PawnRenderer_Zombiefied renderer;
-
-        // Token: 0x04002DA7 RID: 11687
         public PawnUIOverlay ui;
-
-        // Token: 0x04002DA8 RID: 11688
         private PawnFootprintMaker footprintMaker;
-
-        // Token: 0x04002DA9 RID: 11689
         private PawnBreathMoteMaker breathMoteMaker;
-
-        // Token: 0x04002DAA RID: 11690
         private const float MeleeJitterDistance = 0.5f;
     }
 }

--- a/Source/RCellFinder_Zombiefied.cs
+++ b/Source/RCellFinder_Zombiefied.cs
@@ -200,7 +200,7 @@ namespace Zombiefied
             {
                 Log.Warning("wanderRadius of " + radius + " is greater than Region.GridSize of 12 and will break");
             }
-            bool flag = false;
+            bool flag = false;// UnityData.isDebugBuild && DebugViewSettings.drawDestSearch;
             if (root.GetRegion(pawn.Map, RegionType.Set_Passable) != null)
             {
                 int maxRegions = Mathf.Max((int)radius / 3, 13);
@@ -264,7 +264,7 @@ namespace Zombiefied
 
         private static bool CanWanderToCell(IntVec3 c, Pawn pawn, IntVec3 root, Func<Pawn, IntVec3, IntVec3, bool> validator, int tryIndex, Danger maxDanger)
         {
-            bool flag = false;
+            bool flag = false;// UnityData.isDebugBuild && DebugViewSettings.drawDestSearch;
             if (!c.Walkable(pawn.Map))
             {
                 if (flag)
@@ -273,6 +273,99 @@ namespace Zombiefied
                 }
                 return false;
             }
+            /*
+            if (c.IsForbidden(pawn))
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.25f, "forbid", 50);
+                }
+                return false;
+            }
+            */
+            /*
+            if (tryIndex < 10 && !c.Standable(pawn.Map))
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.25f, "stand", 50);
+                }
+                return false;
+            }
+            if (!pawn.CanReach(c, PathEndMode.OnCell, maxDanger, false, TraverseMode.ByPawn))
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.6f, "reach", 50);
+                }
+                return false;
+            }
+            if (c.ContainsStaticFire(pawn.Map))
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.9f, "fire", 50);
+                }
+                return true;
+            }
+            */
+            /*
+            if (PawnUtility.KnownDangerAt(c, pawn.Map, pawn))
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.1f, "trap", 50);
+                }
+                return false;
+            }
+            */
+            /*
+            if (tryIndex < 10)
+            {
+                if (c.GetTerrain(pawn.Map).avoidWander)
+                {
+                    if (flag)
+                    {
+                        pawn.Map.debugDrawer.FlashCell(c, 0.39f, "terr", 50);
+                    }
+                    return false;
+                }
+                if (pawn.Map.pathGrid.PerceivedPathCostAt(c) > 20)
+                {
+                    if (flag)
+                    {
+                        pawn.Map.debugDrawer.FlashCell(c, 0.4f, "pcost", 50);
+                    }
+                    return false;
+                }
+                if (c.GetDangerFor(pawn, pawn.Map) > Danger.None)
+                {
+                    if (flag)
+                    {
+                        pawn.Map.debugDrawer.FlashCell(c, 0.4f, "danger", 50);
+                    }
+                    return false;
+                }
+            }
+            */
+            /*
+            else if (tryIndex < 15 && c.GetDangerFor(pawn, pawn.Map) == Danger.Deadly)
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.4f, "deadly", 50);
+                }
+                return false;
+            }
+            if (!pawn.Map.pawnDestinationReservationManager.CanReserve(c, pawn, false))
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.75f, "resvd", 50);
+                }
+                return false;
+            }
+            */
             if (validator != null && !validator(pawn, c, root))
             {
                 if (flag)
@@ -281,6 +374,25 @@ namespace Zombiefied
                 }
                 return false;
             }
+            /*
+            if (c.GetDoor(pawn.Map) != null)
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.32f, "door", 50);
+                }
+                return false;
+            }
+            
+            if (c.ContainsStaticFire(pawn.Map))
+            {
+                if (flag)
+                {
+                    pawn.Map.debugDrawer.FlashCell(c, 0.9f, "fire", 50);
+                }
+                return false;
+            }
+            */
             return true;
         }
 

--- a/Source/RCellFinder_Zombiefied.cs
+++ b/Source/RCellFinder_Zombiefied.cs
@@ -200,7 +200,7 @@ namespace Zombiefied
             {
                 Log.Warning("wanderRadius of " + radius + " is greater than Region.GridSize of 12 and will break");
             }
-            bool flag = false;// UnityData.isDebugBuild && DebugViewSettings.drawDestSearch;
+            bool flag = false;
             if (root.GetRegion(pawn.Map, RegionType.Set_Passable) != null)
             {
                 int maxRegions = Mathf.Max((int)radius / 3, 13);
@@ -264,7 +264,7 @@ namespace Zombiefied
 
         private static bool CanWanderToCell(IntVec3 c, Pawn pawn, IntVec3 root, Func<Pawn, IntVec3, IntVec3, bool> validator, int tryIndex, Danger maxDanger)
         {
-            bool flag = false;// UnityData.isDebugBuild && DebugViewSettings.drawDestSearch;
+            bool flag = false;
             if (!c.Walkable(pawn.Map))
             {
                 if (flag)
@@ -273,99 +273,6 @@ namespace Zombiefied
                 }
                 return false;
             }
-            /*
-            if (c.IsForbidden(pawn))
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.25f, "forbid", 50);
-                }
-                return false;
-            }
-            */
-            /*
-            if (tryIndex < 10 && !c.Standable(pawn.Map))
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.25f, "stand", 50);
-                }
-                return false;
-            }
-            if (!pawn.CanReach(c, PathEndMode.OnCell, maxDanger, false, TraverseMode.ByPawn))
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.6f, "reach", 50);
-                }
-                return false;
-            }
-            if (c.ContainsStaticFire(pawn.Map))
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.9f, "fire", 50);
-                }
-                return true;
-            }
-            */
-            /*
-            if (PawnUtility.KnownDangerAt(c, pawn.Map, pawn))
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.1f, "trap", 50);
-                }
-                return false;
-            }
-            */
-            /*
-            if (tryIndex < 10)
-            {
-                if (c.GetTerrain(pawn.Map).avoidWander)
-                {
-                    if (flag)
-                    {
-                        pawn.Map.debugDrawer.FlashCell(c, 0.39f, "terr", 50);
-                    }
-                    return false;
-                }
-                if (pawn.Map.pathGrid.PerceivedPathCostAt(c) > 20)
-                {
-                    if (flag)
-                    {
-                        pawn.Map.debugDrawer.FlashCell(c, 0.4f, "pcost", 50);
-                    }
-                    return false;
-                }
-                if (c.GetDangerFor(pawn, pawn.Map) > Danger.None)
-                {
-                    if (flag)
-                    {
-                        pawn.Map.debugDrawer.FlashCell(c, 0.4f, "danger", 50);
-                    }
-                    return false;
-                }
-            }
-            */
-            /*
-            else if (tryIndex < 15 && c.GetDangerFor(pawn, pawn.Map) == Danger.Deadly)
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.4f, "deadly", 50);
-                }
-                return false;
-            }
-            if (!pawn.Map.pawnDestinationReservationManager.CanReserve(c, pawn, false))
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.75f, "resvd", 50);
-                }
-                return false;
-            }
-            */
             if (validator != null && !validator(pawn, c, root))
             {
                 if (flag)
@@ -374,25 +281,6 @@ namespace Zombiefied
                 }
                 return false;
             }
-            /*
-            if (c.GetDoor(pawn.Map) != null)
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.32f, "door", 50);
-                }
-                return false;
-            }
-            
-            if (c.ContainsStaticFire(pawn.Map))
-            {
-                if (flag)
-                {
-                    pawn.Map.debugDrawer.FlashCell(c, 0.9f, "fire", 50);
-                }
-                return false;
-            }
-            */
             return true;
         }
 

--- a/Source/RCellFinder_Zombiefied.cs
+++ b/Source/RCellFinder_Zombiefied.cs
@@ -198,14 +198,7 @@ namespace Zombiefied
         {
             if (radius > 12f)
             {
-                Log.Warning(string.Concat(new object[]
-                {
-                    "wanderRadius of ",
-                    radius,
-                    " is greater than Region.GridSize of ",
-                    12,
-                    " and will break."
-                }), false);
+                Log.Warning("wanderRadius of " + radius + " is greater than Region.GridSize of 12 and will break");
             }
             bool flag = false;// UnityData.isDebugBuild && DebugViewSettings.drawDestSearch;
             if (root.GetRegion(pawn.Map, RegionType.Set_Passable) != null)
@@ -507,19 +500,7 @@ namespace Zombiefied
             if (!CellFinderLoose.TryGetRandomCellWith(validator, map, 1000, out intVec))
             {
                 intVec = CellFinder.RandomCell(map);
-                Log.Warning(string.Concat(new object[]
-                {
-                    "RandomAnimalSpawnCell_MapGen failed: numStand=",
-                    numStand,
-                    ", numRoom=",
-                    numRoom,
-                    ", numTouch=",
-                    numTouch,
-                    ". PlayerStartSpot=",
-                    MapGenerator.PlayerStartSpot,
-                    ". Returning ",
-                    intVec
-                }), false);
+                Log.Warning("Random RandomAnimalSpawnCell_MapGen failed: numStand="+numStand+", numRoom="+numRoom+", numTouch="+numTouch+" PlayerStartSpot="+MapGenerator.PlayerStartSpot+". Returning "+intVec);
             }
             return intVec;
         }
@@ -620,10 +601,9 @@ namespace Zombiefied
                     return false;
                 }
                 int num = 0;
-                CellRect.CellRectIterator iterator = CellRect.CenteredOn(c, walkRadius).GetIterator();
-                while (!iterator.Done())
+                foreach (IntVec3 cell in CellRect.CenteredOn(c, walkRadius))
                 {
-                    Room room2 = iterator.Current.GetRoom(map);
+                    Room room2 = cell.GetRoom(map);
                     if (room2 != room)
                     {
                         num++;
@@ -636,7 +616,6 @@ namespace Zombiefied
                     {
                         return false;
                     }
-                    iterator.MoveNext();
                 }
                 if (minColonyBuildingsLOS > 0)
                 {
@@ -1096,7 +1075,7 @@ namespace Zombiefied
                 {
                     intVec = CellFinder.RandomCell(map);
                 }
-                Log.Error("Tried to find a siege position from an invalid cell. Using " + intVec, false);
+                Log.Error("Tried to find a siege position from an invalid cell. Using " + intVec);
                 return intVec;
             }
             IntVec3 result;
@@ -1111,13 +1090,7 @@ namespace Zombiefied
             {
                 return result;
             }
-            Log.Error(string.Concat(new object[]
-            {
-                "Could not find siege spot from ",
-                entrySpot,
-                ", using ",
-                entrySpot
-            }), false);
+            Log.Error("Could not find siege spot from " + entrySpot);
             return entrySpot;
         }
 
@@ -1168,14 +1141,13 @@ namespace Zombiefied
                                     if (!randomCell.Roofed(map))
                                     {
                                         int num3 = 0;
-                                        CellRect.CellRectIterator iterator = CellRect.CenteredOn(randomCell, 10).ClipInsideMap(map).GetIterator();
-                                        while (!iterator.Done())
+                                        foreach (IntVec3 cell in CellRect.CenteredOn(randomCell, 10).ClipInsideMap(map))
                                         {
+                                            // Should this use the iterated variable, "cell", rather than "randomCell"?
                                             if (randomCell.SupportsStructureType(map, TerrainAffordanceDefOf.Heavy) && randomCell.SupportsStructureType(map, TerrainAffordanceDefOf.Light))
                                             {
-                                                num3++;
+                                               num3++;
                                             }
-                                            iterator.MoveNext();
                                         }
                                         if (num3 >= 35)
                                         {

--- a/Source/ThinkNode_ConditionalCanDoConstantThinkTreeJobNow_Zombiefied.cs
+++ b/Source/ThinkNode_ConditionalCanDoConstantThinkTreeJobNow_Zombiefied.cs
@@ -5,10 +5,8 @@ using RimWorld;
 
 namespace Zombiefied
 {
-    // Token: 0x020001E0 RID: 480
     public class ThinkNode_ConditionalCanDoConstantThinkTreeJobNow_Zombiefied : ThinkNode_Conditional
     {
-        // Token: 0x0600098D RID: 2445 RVA: 0x000579F4 File Offset: 0x00055DF4
         protected override bool Satisfied(Pawn pawn)
         {
             return !pawn.Downed && !pawn.InMentalState && !pawn.Drafted && pawn.Awake();

--- a/Source/ThinkNode_ConditionalExitMap_Zombiefied.cs
+++ b/Source/ThinkNode_ConditionalExitMap_Zombiefied.cs
@@ -5,10 +5,8 @@ using RimWorld;
 
 namespace Zombiefied
 {
-    // Token: 0x020001E0 RID: 480
     public class ThinkNode_ConditionalExitMap_Zombiefied : ThinkNode_Conditional
     {
-        // Token: 0x0600098D RID: 2445 RVA: 0x000579F4 File Offset: 0x00055DF4
         protected override bool Satisfied(Pawn pawn)
         {
             if(ZombiefiedMod.zombieAmountsPerMap != null && ZombiefiedMod.zombieAmountsPerMap.Count > pawn.Map.Index)

--- a/Source/ZombieData.cs
+++ b/Source/ZombieData.cs
@@ -41,6 +41,7 @@ namespace Zombiefied
             else
             {
                 string reflectedPath = pawn.story.GetFieldValue<string>("headGraphicPath");
+                //Log.Message("++" + reflectedPath + "++");
                 if (reflectedPath != null && reflectedPath.Length > 7)
                 {
                     this.headGraphicPath = reflectedPath;
@@ -73,6 +74,7 @@ namespace Zombiefied
             this.color = color;
             this.hairColor = hairColor;
             this.shaderCutoutPath = shaderCutoutPath;
+            //this.wornApparelDefs = new List<ThingDef>(source.wornApparelDefs);
         }
         public void ExposeData()
         {

--- a/Source/ZombieData.cs
+++ b/Source/ZombieData.cs
@@ -6,10 +6,8 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000016 RID: 22
     public class ZombieData : IExposable
     {
-        // Token: 0x0600006A RID: 106 RVA: 0x0000303E File Offset: 0x0000123E
         public ZombieData()
         {
             this.hairColor = Color.green;
@@ -26,16 +24,12 @@ namespace Zombiefied
             this.wornApparelColors = new List<Color>();
 
         }
-
-        // Token: 0x0600006B RID: 107 RVA: 0x00004630 File Offset: 0x00002830
         public ZombieData(Color color, Color hairColor, string shaderCutoutPath)
         {
             this.color = color;
             this.hairColor = hairColor;
             this.shaderCutoutPath = shaderCutoutPath;
         }
-
-        // Token: 0x0600006C RID: 108 RVA: 0x00004648 File Offset: 0x00002848
         public ZombieData(Pawn pawn)
         {
             this.bodyType = pawn.story.bodyType;
@@ -71,8 +65,6 @@ namespace Zombiefied
                 this.wornApparelColors.Add(worn.DrawColor);
             }
         }
-
-        // Token: 0x0600006D RID: 109 RVA: 0x000046E8 File Offset: 0x000028E8
         public ZombieData(ZombieData source, Color color, Color hairColor, string shaderCutoutPath)
         {
             this.bodyType = source.bodyType;
@@ -84,20 +76,6 @@ namespace Zombiefied
             this.shaderCutoutPath = shaderCutoutPath;
             //this.wornApparelDefs = new List<ThingDef>(source.wornApparelDefs);
         }
-
-        /*
-        // Token: 0x0600006E RID: 110 RVA: 0x0000474C File Offset: 0x0000294C
-        public void CopyFromPreset(ZombiePreset preset)
-        {
-            this.bodyType = preset.bodyType;
-            this.headGraphicPath = preset.headGraphicPath;
-            this.hairGraphicPath = preset.hairDef.texPath;
-            this.crownType = preset.crownType;
-            this.wornApparelDefs = preset.apparels.ConvertAll<ThingDef>((ZombieApparelData data) => data.apparelDef);
-        }
-        */
-
-        // Token: 0x0600006F RID: 111 RVA: 0x000047C0 File Offset: 0x000029C0
         public void ExposeData()
         {
             Scribe_Defs.Look<BodyTypeDef>(ref this.bodyType, "bodyTypeDef");
@@ -110,8 +88,6 @@ namespace Zombiefied
             Scribe_Collections.Look<ThingDef>(ref this.wornApparelDefs, "wornApparelDefs", LookMode.Def, new object[0]);
             Scribe_Collections.Look<Color>(ref this.wornApparelColors, "wornApparelColors", LookMode.Value, new object[0]);
         }
-
-        // Token: 0x06000070 RID: 112 RVA: 0x00004858 File Offset: 0x00002A58
         public bool CanWearWithoutDroppingAnything(ThingDef apDef)
         {
             for (int i = 0; i < this.wornApparelDefs.Count; i++)
@@ -123,30 +99,14 @@ namespace Zombiefied
             }
             return true;
         }
-
-        // Token: 0x0400005C RID: 92
         public BodyTypeDef bodyType;
-
-        // Token: 0x0400005D RID: 93
         public string headGraphicPath;
-
-        // Token: 0x0400005E RID: 94
         public string hairGraphicPath;
-
-        // Token: 0x0400005F RID: 95
         public CrownType crownType;
-
-        // Token: 0x04000060 RID: 96
         public Color color;
-
         public Color hairColor;
-
-        // Token: 0x04000061 RID: 97
         public string shaderCutoutPath;
-
-        // Token: 0x04000062 RID: 98
         public List<ThingDef> wornApparelDefs;
-
         public List<Color> wornApparelColors;
     }
 }

--- a/Source/ZombieData.cs
+++ b/Source/ZombieData.cs
@@ -41,7 +41,6 @@ namespace Zombiefied
             else
             {
                 string reflectedPath = pawn.story.GetFieldValue<string>("headGraphicPath");
-                //Log.Message("++" + reflectedPath + "++");
                 if (reflectedPath != null && reflectedPath.Length > 7)
                 {
                     this.headGraphicPath = reflectedPath;
@@ -74,7 +73,6 @@ namespace Zombiefied
             this.color = color;
             this.hairColor = hairColor;
             this.shaderCutoutPath = shaderCutoutPath;
-            //this.wornApparelDefs = new List<ThingDef>(source.wornApparelDefs);
         }
         public void ExposeData()
         {

--- a/Source/ZombieGraphicSet.cs
+++ b/Source/ZombieGraphicSet.cs
@@ -6,11 +6,8 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000017 RID: 23
     public class ZombieGraphicSet
     {
-        // Token: 0x17000010 RID: 16
-        // (get) Token: 0x06000071 RID: 113 RVA: 0x000048A1 File Offset: 0x00002AA1
         public bool AllResolved
         {
             get
@@ -19,8 +16,6 @@ namespace Zombiefied
             }
         }
 
-        // Token: 0x17000011 RID: 17
-        // (get) Token: 0x06000072 RID: 114 RVA: 0x000048AC File Offset: 0x00002AAC
         public GraphicMeshSet HairMeshSet
         {
             get
@@ -37,14 +32,10 @@ namespace Zombiefied
                 return MeshPool.humanlikeHairSetAverage;
             }
         }
-
-        // Token: 0x06000073 RID: 115 RVA: 0x00004905 File Offset: 0x00002B05
         public ZombieGraphicSet(ZombieData data)
         {
             this.data = data;
         }
-
-        // Token: 0x06000074 RID: 116 RVA: 0x00004934 File Offset: 0x00002B34
         public List<Material> MatsBodyBaseAt(Rot4 facing, RotDrawMode bodyCondition = RotDrawMode.Fresh)
         {
             int num = facing.AsInt + 1000 * (int)bodyCondition;
@@ -74,8 +65,6 @@ namespace Zombiefied
             }
             return this.cachedMatsBodyBase;
         }
-
-        // Token: 0x06000075 RID: 117 RVA: 0x00004A54 File Offset: 0x00002C54
         public Material HeadMatAt(Rot4 facing, RotDrawMode bodyCondition = RotDrawMode.Fresh, bool stump = false)
         {
             Material result = null;
@@ -107,20 +96,14 @@ namespace Zombiefied
             }
             return result;
         }
-
-        // Token: 0x06000076 RID: 118 RVA: 0x00004AC6 File Offset: 0x00002CC6
         public Material HairMatAt(Rot4 facing)
         {
             return this.hairGraphic.MatAt(facing, null);
         }
-
-        // Token: 0x06000077 RID: 119 RVA: 0x00004AD5 File Offset: 0x00002CD5
         public void ClearCache()
         {
             this.cachedMatsBodyBaseHash = -1;
         }
-
-        // Token: 0x06000078 RID: 120 RVA: 0x00004AE0 File Offset: 0x00002CE0
         public void ResolveAllGraphics(float scale = 1f)
         {
             Shader shader = ShaderDatabase.LoadShader(this.data.shaderCutoutPath);
@@ -136,8 +119,6 @@ namespace Zombiefied
             this.hairGraphic = GraphicDatabase.Get<Graphic_Multi>(this.data.hairGraphicPath, shader, Vector2.one, this.data.hairColor);
             this.ResolveApparelGraphics();
         }
-
-        // Token: 0x06000079 RID: 121 RVA: 0x00004BF8 File Offset: 0x00002DF8
         public void ResolveApparelGraphics()
         {
             /*
@@ -180,8 +161,6 @@ namespace Zombiefied
             }
             */
         }
-
-        // Token: 0x0600007A RID: 122 RVA: 0x00004CA8 File Offset: 0x00002EA8
         private Apparel MakeApparel(int index)
         {
             ThingDef def = this.data.wornApparelDefs[index];
@@ -192,8 +171,6 @@ namespace Zombiefied
             }                      
             return apparel;
         }
-
-        // Token: 0x0600007B RID: 123 RVA: 0x00004CC4 File Offset: 0x00002EC4
         private static bool TryGetGraphicApparel(Apparel apparel, Color color, BodyTypeDef bodyType, Shader shader, out ApparelGraphicRecord rec)
         {
             /*
@@ -229,47 +206,19 @@ namespace Zombiefied
             rec = new ApparelGraphicRecord();
             return false;
         }
-
-        // Token: 0x04000063 RID: 99
         public ZombieData data;
-
-        // Token: 0x04000064 RID: 100
         public Graphic nakedGraphic;
-
-        // Token: 0x04000065 RID: 101
         public Graphic rottingGraphic;
-
-        // Token: 0x04000066 RID: 102
         public Graphic dessicatedGraphic;
-
-        // Token: 0x04000067 RID: 103
         public Graphic headGraphic;
-
-        // Token: 0x04000068 RID: 104
         public Graphic desiccatedHeadGraphic;
-
-        // Token: 0x04000069 RID: 105
         public Graphic skullGraphic;
-
-        // Token: 0x0400006A RID: 106
         public Graphic headStumpGraphic;
-
-        // Token: 0x0400006B RID: 107
         public Graphic desiccatedHeadStumpGraphic;
-
-        // Token: 0x0400006C RID: 108
         public Graphic hairGraphic;
-
-        // Token: 0x0400006D RID: 109
         public List<ApparelGraphicRecord> apparelGraphics = new List<ApparelGraphicRecord>();
-
-        // Token: 0x0400006E RID: 110
         private List<Material> cachedMatsBodyBase = new List<Material>();
-
-        // Token: 0x0400006F RID: 111
         private int cachedMatsBodyBaseHash = -1;
-
-        // Token: 0x04000070 RID: 112
         public static readonly Color RottingColor = new Color(0.34f, 0.32f, 0.3f);
     }
 }

--- a/Source/ZombiefiedMod.cs
+++ b/Source/ZombiefiedMod.cs
@@ -459,7 +459,6 @@ namespace Zombiefied
             int currentMapIndex = -7;
 
             IntVec3 location = IntVec3.Invalid;
-            float num = 0f;
 
             for (int i = 0; i < Find.Maps.Count; i++)
             {
@@ -478,16 +477,6 @@ namespace Zombiefied
             if (locations != null && locations.Count > 0)
             {
                 location = locations[locations.Count - 1];
-                /*
-                for (int i = 0; i < locations.Count; i++)
-                {
-                    if (location == IntVec3.Invalid || num > (predator.Position - locations[i]).LengthHorizontal)
-                    {
-                        location = locations[i];
-                        num = (predator.Position - locations[i]).LengthHorizontal;
-                    }
-                }
-                */
             }
 
             return location;

--- a/Source/ZombiefiedMod.cs
+++ b/Source/ZombiefiedMod.cs
@@ -11,14 +11,11 @@ using Verse;
 
 namespace Zombiefied
 {
-    // Token: 0x02000008 RID: 8
     public class ZombiefiedMod : ModBase
     {
         public static JobDef zombieHunt;
         public static JobDef zombieMove;
 
-        // Token: 0x17000001 RID: 1
-        // (get) Token: 0x06000018 RID: 24 RVA: 0x00002A68 File Offset: 0x00000C68
         public override string ModIdentifier
         {
             get
@@ -26,8 +23,6 @@ namespace Zombiefied
                 return "Zombiefied";
             }
         }
-
-        // Token: 0x06000019 RID: 25 RVA: 0x00002A82 File Offset: 0x00000C82
         public override void WorldLoaded()
         {
             base.Logger.Message("loaded", new object[0]);
@@ -429,9 +424,6 @@ namespace Zombiefied
                                                 bestLocation = building2.Position;
                                                 bestLocationTicks = building2.LastAttackTargetTick;
                                             }
-
-                                            //noisyLocationsPerMap[m].Enqueue(building2.Position);
-                                            //noisyLocationTicksPerMap[m].Enqueue(building2.LastAttackTargetTick);
                                         }
                                     }
                                 }
@@ -449,7 +441,6 @@ namespace Zombiefied
 
                     log += "map " + m + " has " + noisyLocationsPerMap[m].Count + " noisy locations and " + zombieAmountsPerMap[m] + " zombies.   ";
                 }
-                //base.Logger.Message(log, new object[0]);
             }
         }
 
@@ -481,15 +472,12 @@ namespace Zombiefied
 
             return location;
         }
-
-        // Token: 0x0600001E RID: 30 RVA: 0x00002BBC File Offset: 0x00000DBC
         private void HandleReanimation()
         {
             if (Find.TickManager.TicksAbs % 1777 == 7)
             {
                 foreach (Map map in Find.Maps)
                 {
-                    //List<Thing> list = map.listerThings.ThingsInGroup(ThingRequestGroup.Corpse);
                     List<Thing> list = map.listerThings.AllThings;
                     if (list != null)
                     {

--- a/Source/ZombiefiedMod.cs
+++ b/Source/ZombiefiedMod.cs
@@ -54,14 +54,10 @@ namespace Zombiefied
                     zFaction = faction;
                 }
             }
-            //Faction.OfMechanoids.TrySetNotHostileTo(zFaction);
             zFaction.RelationWith(Faction.OfMechanoids).kind = FactionRelationKind.Ally;
-            //zFaction.RelationWith(Faction.OfMechanoids).goodwill = 100;
             zFaction.RelationWith(Faction.OfMechanoids).baseGoodwill = 100;
             Faction.OfMechanoids.RelationWith(zFaction).kind = FactionRelationKind.Ally;
             Faction.OfMechanoids.RelationWith(zFaction).baseGoodwill = 100;
-            //zFaction.TrySetNotHostileTo(Faction.OfMechanoids);
-            //zFaction.TryMakeInitialRelationsWith(Faction.OfMechanoids);
 
             int zKilled = 0;
             int zCount = 0;
@@ -88,35 +84,7 @@ namespace Zombiefied
                 }
             }
 
-            /*
-            foreach (RimWorld.Planet.Site site in Find.World.worldObjects.Sites)
-            {
-                bool broken = false;
-                if (site != null)
-                {
-                    if (site.core == null || site.core.def == null || site.core.def.Worker == null || site.core.def.workerClass == null)
-                    {
-                        broken = true;
-                    }
-
-                    foreach (RimWorld.Planet.SitePart part in site.parts)
-                    {
-                        if(part.def == null || part.def.Worker == null || part.def.workerClass == null)
-                        {
-                            broken = true;
-                        }
-                    }
-                }
-                if(broken)
-                {
-                    base.Logger.Message("found a broken site.");
-                    //handle broken site here
-                }
-            }
-            */
-
             debugRemoveZombies.Value = false;
-            //base.Logger.Message("found " + zCount + " Zombies. " + zWrongFactionCount + " of them were repaired.", new object[0]);
         }
 
         public override void DefsLoaded()
@@ -127,8 +95,6 @@ namespace Zombiefied
             };
             headlineZombieOptions = base.Settings.GetHandle<bool>("headlineZombies", "\nZombie settings:", "Zombie settings", false, null, null);
             headlineZombieOptions.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
-            //headlineZombieOptions.CustomDrawerHeight = 37f;
-
             disableAnimalZombies = base.Settings.GetHandle<bool>("disableAnimalZombies", "       Disable animal zombies", "Animals will not resurrect and no animal zombies will wander in.", false, null, null);
             disableZombiesAttackingAnimals = base.Settings.GetHandle<bool>("disableZombiesAttackingAnimals", "       Disable zombies attacking animals", "Zombies will ignore animals.", false, null, null);
             zombieSpeedMultiplier = base.Settings.GetHandle<float>("ZombieSpeedMultiplier", "       Zombie speed multiplier [RESTART]", "Zombie speed (in comparison to healthy) will be multiplied by this value.\n(0.03 -> Slowest, 3 -> Fastest)\n(Requires restart to work)", 0.57f, null, null);
@@ -145,9 +111,6 @@ namespace Zombiefied
 
             headlineZombieAmount = base.Settings.GetHandle<bool>("headlineAmounts", "\nAmount settings:", "Amount settings", false, null, null);
             headlineZombieAmount.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
-            //headlineZombieAmount.CustomDrawerHeight = 37f;
-
-            //easyMode = base.Settings.GetHandle<bool>("EasyMode", "Easy mode", "Keep in mind that you are not meant to kill all zombies at all times and losing is part of the game.", false, null, null);
             zombieAmountSoftCap = base.Settings.GetHandle<int>("ZombieAmountSoftCap", "       Zombie amount soft cap", "The expected amount of zombies per map.", 133, null, null);
 
             zombieRaidAmountMultiplier = base.Settings.GetHandle<float>("ZombieRaidAmountMultiplier", "       Zombie raid size multiplier", "Zombie raid size will be multiplied by this value.\n(0.1 -> Easiest, 7 -> Hardest)", 1f, null, null);
@@ -155,39 +118,24 @@ namespace Zombiefied
 
             headlineNotifications = base.Settings.GetHandle<bool>("headlineNotifications", "\nNotification settings:", "Notification settings", false, null, null);
             headlineNotifications.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
-            //headlineNotifications.CustomDrawerHeight = 37f;
 
             zombieRaidNotifications = base.Settings.GetHandle<bool>("ZombieRaidNotifications", "       Zombie raid notifications", "Get a notification when zombies wander in.", true, null, null);
             zombieResurrectNotifications = base.Settings.GetHandle<bool>("ZombieResurrectNotifications", "       Zombie resurrect notifications", "Get a notification when a zombie resurrects.", false, null, null);
 
             headlineDebug = base.Settings.GetHandle<bool>("headlineDebug", "\nDebug settings:", "Debug settings", false, null, null);
             headlineDebug.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
-            //headlineDebug.CustomDrawerHeight = 37f;
 
             debugRemoveZombies = base.Settings.GetHandle<bool>("DebugRemoveZombies", "       Debug remove zombies [RELOAD]", "Enable this and reload to remove all zombies on next load.", false, null, null);
-
-            /*
-            zombieSoundReactionTimeInHours.CustomDrawerHeight = 77;
-            zombieAmountSoftCap.CustomDrawerHeight = 77;
-            zombieRaidAmountMultiplier.CustomDrawerHeight = 77;
-            zombieRaidFrequencyMultiplier.CustomDrawerHeight = 77;
-            zombieRaidNotifications.CustomDrawerHeight = 77;
-            zombieResurrectNotifications.CustomDrawerHeight = 77;
-            debugRemoveZombies.CustomDrawerHeight = 77;
-            */
 
             InitializeCustom();
         }
 
         internal static SettingHandle<bool> headlineZombieOptions;
-        //
         internal static SettingHandle<bool> disableAnimalZombies;
         internal static SettingHandle<bool> disableZombiesAttackingAnimals;
         internal static SettingHandle<float> zombieSpeedMultiplier;
         internal static SettingHandle<int> zombieSoundReactionTimeInHours;
-
         internal static SettingHandle<bool> headlineZombieAmount;
-        //
         internal static SettingHandle<float> zombieRaidFrequencyMultiplier;
         public static float ZombieRaidFrequencyMultiplier
         {
@@ -221,14 +169,10 @@ namespace Zombiefied
             }
         }
         internal static SettingHandle<int> zombieAmountSoftCap;
-
         internal static SettingHandle<bool> headlineNotifications;
-        //
         internal static SettingHandle<bool> zombieRaidNotifications;
         internal static SettingHandle<bool> zombieResurrectNotifications;
-
         internal static SettingHandle<bool> headlineDebug;
-        //
         internal static SettingHandle<bool> debugRemoveZombies;
 
         public override void Tick(int currentTick)
@@ -245,10 +189,7 @@ namespace Zombiefied
             {
                 num = 0.7f;
             }
-            //if (easyMode)
-            //{
             num /= ZombieRaidFrequencyMultiplier;
-            //}
             if ((double)num < 0.17f)
             {
                 num = 0.17f;
@@ -263,10 +204,7 @@ namespace Zombiefied
         private int GenerateTicksUntilNextRaid()
         {
             float challengeModifier = this.GetChallengeModifier();
-            //int num = UnityEngine.Random.Range((int)((float)ZombiesDefOf.ZombiesSettings.MinRaidTicksBase * challengeModifier), (int)((float)ZombiesDefOf.ZombiesSettings.MaxRaidTicksBase * challengeModifier));
             int num = Rand.RangeSeeded((int)((float)7777 * challengeModifier), (int)((float)280000 * challengeModifier), Find.TickManager.TicksAbs + Find.World.ConstantRandSeed);
-            //if (first && num < ZombiesDefOf.ZombiesSettings.MinTicksBeforeFirstRaid)
-            //base.Logger.Message("next zombieraid in " + num + " ticks.", new object[0]);
             return num;
         }
 
@@ -278,9 +216,6 @@ namespace Zombiefied
                 if (this._ticksUntilNextZombieRaid[currentMapIndex] <= 0)
                 {
                     this._ticksUntilNextZombieRaid[currentMapIndex] = this.GenerateTicksUntilNextRaid();
-
-                    //base.Logger.Message("setting up zombieraid for map " + currentMapIndex + ".", new object[0]);
-
                     if (currentMapIndex < zombieAmountsPerMap.Count && zombieAmountsPerMap[currentMapIndex] < zombieAmountSoftCap)
                     {
                         IncidentParms incidentParms = new IncidentParms
@@ -297,11 +232,6 @@ namespace Zombiefied
                         {
                             IncidentDef.Named("ZombiePack").Worker.TryExecute(incidentParms);
                         }
-                        //base.Logger.Message("Zombieraid started on map " + currentMapIndex + ".", new object[0]);
-                    }
-                    else
-                    {
-                        //base.Logger.Message("Zombieraid failed on map " + currentMapIndex + " because map invalid or more zombies are already on the map than cap allows.", new object[0]);
                     }
                 }
             }
@@ -324,7 +254,7 @@ namespace Zombiefied
                 {
                     if (noisyLocationsPerMap[m].Count > 0)
                     {
-                        if (Find.TickManager.TicksGame - noisyLocationTicksPerMap[m].Peek() > zombieSoundReactionTimeInHours * 2500) //7777)
+                        if (Find.TickManager.TicksGame - noisyLocationTicksPerMap[m].Peek() > zombieSoundReactionTimeInHours * 2500)
                         {
                             noisyLocationsPerMap[m].Dequeue();
                             noisyLocationTicksPerMap[m].Dequeue();
@@ -391,9 +321,6 @@ namespace Zombiefied
                                                 bestLocation = pawn2.Position;
                                                 bestLocationTicks = pawn2.LastAttackTargetTick;
                                             }
-
-                                            //noisyLocationsPerMap[m].Enqueue(pawn2.Position);
-                                            //noisyLocationTicksPerMap[m].Enqueue(pawn2.LastAttackTargetTick);
                                         }
                                         shotsFiredPerPawn[key] = pawn2.records.GetAsInt(RecordDefOf.ShotsFired);
                                     }
@@ -517,9 +444,7 @@ namespace Zombiefied
 
         public Pawn ReanimateDeath(Corpse corpse)
         {
-            //base.Logger.Message(corpse.InnerPawn.story.HeadGraphicPath, new object[0]);
             Pawn_Zombiefied zombiePawn = ZombiefiedMod.GenerateZombieFromSource(corpse.InnerPawn);
-            //Pawn zombiePawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Alphabeaver, Faction.OfPlayer);
             IntVec3 position = corpse.Position;
             Building building = StoreUtility.StoringThing(corpse) as Building;
             Building_Storage building_Storage = (Building_Storage)building;
@@ -531,12 +456,6 @@ namespace Zombiefied
 
             Thing t = GenSpawn.Spawn(zombiePawn, position, corpse.Map);
             corpse.TakeDamage(new DamageInfo(DamageDefOf.Deterioration, 77777f));
-
-            //for(int i = 0; i < Find.BattleLog.Battles.Count; i++)
-            //{
-            //InteractionCardUtility_Zombiefied.DrawInteractionsLog(corpse.InnerPawn, t, Find.BattleLog.Battles[i].Entries, 50);
-            //}
-            //InteractionCardUtility_Zombiefied.DrawInteractionsLog(corpse.InnerPawn, t, Find.BattleLog.RawEntries, 50);
 
             if (zombieResurrectNotifications && t != null)
             {
@@ -586,7 +505,6 @@ namespace Zombiefied
 
             pawn.records = sourcePawn.records;
             pawn.gender = sourcePawn.gender;
-            //pawn.needs.SetInitialLevels();
 
             if (sourcePawn.Faction != null && sourcePawn.Faction.IsPlayer)
             {
@@ -681,8 +599,6 @@ namespace Zombiefied
                 }
             }
             ThingRequestGroupUtility.StoreInRegion(ThingRequestGroup.Corpse);
-            //Pawn pawntest;
-            //pawntest.Map.listerThings.Add
 
             bool first = true;
             List<PawnKindDef> listPawnKindDef = DefDatabase<PawnKindDef>.AllDefsListForReading;
@@ -698,17 +614,16 @@ namespace Zombiefied
                         if(sourcePawnKindDef.weaponTags[t].Contains("Melee") && sourcePawnKindDef.weaponTags[t].Contains("Neolithic"))
                         {
                             sourcePawnKindDef.weaponTags[t] = "NeolithicRangedChief";
-                            //sourcePawnKindDef.
                         }
                         log += sourcePawnKindDef.weaponTags[t] + " ";
                     }
-                    //base.Logger.Message(log);
                 }
 
 
                 if (sourcePawnKindDef.defName == null || (sourcePawnKindDef.defName.Length >= 6 && sourcePawnKindDef.defName.Substring(0, 6) == "Zombie") || DefDatabase<PawnKindDef>.GetNamed("Zombie" + sourcePawnKindDef.defName, false) != null)
                 {
-                    //Nothing
+                    // Nothing
+                    // TODO: Refactor this to just use the ! operator or something
                 }
                 else
                 {
@@ -743,12 +658,7 @@ namespace Zombiefied
 
                                 newThingDef.drawGUIOverlay = true;
 
-                                //int e = (int)(sourcePawnKindDef.race.shortHash);
-                                //ushort f = (ushort)(e + 7);
-                                //newThingDef.shortHash = f;
                                 InjectedDefHasher.GiveShortHashToDef(newThingDef, typeof(ThingDef));
-
-                                //reached
 
                                 Predicate<StatModifier> findMoveSpeed = delegate (StatModifier statMod)
                                 {
@@ -821,9 +731,6 @@ namespace Zombiefied
                                     }
                                     return false;
                                 };
-
-                                //reached
-
                                 newThingDef.statBases = new List<StatModifier>();
 
                                 StatModifier newStat = new StatModifier();
@@ -859,18 +766,6 @@ namespace Zombiefied
                                     newThingDef.statBases.Add(newStat);
                                 }
 
-                                /*
-                                StatModifier statHeat = sourcePawnKindDef.race.statBases.Find(findArmorRating_Heat);
-                                if (statHeat != null)
-                                {
-                                    newStat = new StatModifier();
-                                    newStat.stat = StatDefOf.ArmorRating_Heat;
-                                    newStat.value = statHeat.value;
-                                    newThingDef.statBases.Add(newStat);
-                                }
-                                */
-
-
                                 newStat = new StatModifier();
                                 newStat.stat = StatDefOf.PsychicSensitivity;
                                 newStat.value = 0f;
@@ -886,19 +781,17 @@ namespace Zombiefied
                                 newStat.value = sourcePawnKindDef.race.statBases.Find(findMoveSpeed).value * zombieSpeedMultiplier;
                                 newThingDef.statBases.Add(newStat);
 
-                                //setup standard zombie
+                                // Setup standard zombie
                                 if(first)
                                 {
                                     zombieThingDef.statBases.Find(findMoveSpeed).value = 4.6f * zombieSpeedMultiplier;
                                 }
-                                //setup standard zombie
 
                                 //CE SUPPORT
                                 StatModifier statCEDodge;
                                 statCEDodge = sourcePawnKindDef.race.statBases.Find(findMeleeDodgeChance);
                                 if(statCEDodge != null)
                                 {
-                                    //Log.Message("found CE for " + sourcePawnKindDef.defName);
                                     newThingDef.statBases.Add(statCEDodge);
                                     if (first)
                                     {
@@ -925,12 +818,10 @@ namespace Zombiefied
                                         zombieThingDef.statBases.Add(statCEParry);
                                     }
                                 }
-                                //CE SUPPORT
+                                // CE SUPPORT
                                 first = false;
 
                                 newThingDef.BaseMarketValue = sourcePawnKindDef.race.BaseMarketValue;
-
-                                //reached
 
                                 newThingDef.tools = new List<Tool>();
                                 int iTool = -1;
@@ -972,8 +863,6 @@ namespace Zombiefied
                                 newThingDef.race.meatColor = color;
 
                                 newThingDef.race.leatherDef = zombieThingDef.race.leatherDef;
-                                //newThingDef.race.leatherColor = color;
-                                //newThingDef.race.leatherLabel = "zombie" + sourcePawnKindDef.race.race.leatherLabel;
                                 newThingDef.race.useLeatherFrom = zombieThingDef;
                                 newThingDef.race.useMeatFrom = zombieThingDef;
 
@@ -996,7 +885,6 @@ namespace Zombiefied
                                 newThingDef.race.foodType = zombieThingDef.race.foodType;
                                 newThingDef.race.predator = zombieThingDef.race.predator;
                                 newThingDef.race.makesFootprints = sourcePawnKindDef.race.race.makesFootprints;
-                                //newThingDef.race.leatherInsulation = sourcePawnKindDef.race.race.leatherInsulation;
 
                                 newThingDef.race.lifeStageAges = new List<LifeStageAge>();
                                 for (int l = 0; l < sourcePawnKindDef.race.race.lifeStageAges.Count; l++)
@@ -1026,32 +914,20 @@ namespace Zombiefied
                                 newThingDef.ResolveReferences();
                             }
 
-                            //not reached
 
                             PawnKindDef newKindDef = new PawnKindDef();
-                            //newKindDef = PawnKindDef.Named("Zombie");
 
                             newKindDef.defName = "Zombie" + sourcePawnKindDef.defName;
                             newKindDef.label = "zombie " + sourcePawnKindDef.label;
                             newKindDef.race = newThingDef;
-                            //newKindDef.race = ThingDef.Named("Zombie");
 
                             newKindDef.defaultFactionType = PawnKindDef.Named("Zombie").defaultFactionType;
-                            newKindDef.combatPower = 0;// sourcePawnKindDef.combatPower / 2;
+                            newKindDef.combatPower = 0;
                             newKindDef.canArriveManhunter = false;
-
-                            //int s = (int)(sourcePawnKindDef.shortHash);
-                            //ushort z = (ushort)(s + 7);
-                            //newKindDef.shortHash = z;
                             InjectedDefHasher.GiveShortHashToDef(newKindDef, typeof(PawnKindDef));
-
-                            //base.Logger.Message((newKindDef.RaceProps != null) + "");
-
-                            //newKindDef.lifeStages = PawnKindDef.Named("Zombie").lifeStages;
 
                             newKindDef.lifeStages = new List<PawnKindLifeStage>();
 
-                            //newKindDef.lifeStages = sourcePawnKindDef.lifeStages;
                             for (int j = 0; j < sourcePawnKindDef.lifeStages.Count; j++)
                             {
                                 newKindDef.lifeStages.Add(new PawnKindLifeStage());
@@ -1082,12 +958,7 @@ namespace Zombiefied
                                     newKindDef.lifeStages[j].dessicatedBodyGraphicData = new GraphicData();
                                     newKindDef.lifeStages[j].dessicatedBodyGraphicData.CopyFrom(sourcePawnKindDef.lifeStages[j].dessicatedBodyGraphicData);
                                 }
-
-                                //newKindDef.lifeStages[j].ResolveReferences();
-
-                                //newKindDef.lifeStages.Add(n);
                             }
-                            //base.Logger.Message((newKindDef.RaceProps != null) + "");
                             if (newKindDef != null && newThingDef != null && newKindDef.RaceProps != null)
                             {
                                 DefDatabase<PawnKindDef>.Add(newKindDef);

--- a/Source/ZombiefiedMod.cs
+++ b/Source/ZombiefiedMod.cs
@@ -424,6 +424,8 @@ namespace Zombiefied
                                                 bestLocation = building2.Position;
                                                 bestLocationTicks = building2.LastAttackTargetTick;
                                             }
+                                            //noisyLocationsPerMap[m].Enqueue(building2.Position);
+                                            //noisyLocationTicksPerMap[m].Enqueue(building2.LastAttackTargetTick);
                                         }
                                     }
                                 }
@@ -441,6 +443,7 @@ namespace Zombiefied
 
                     log += "map " + m + " has " + noisyLocationsPerMap[m].Count + " noisy locations and " + zombieAmountsPerMap[m] + " zombies.   ";
                 }
+                //base.Logger.Message(log, new object[0]);
             }
         }
 
@@ -468,6 +471,16 @@ namespace Zombiefied
             if (locations != null && locations.Count > 0)
             {
                 location = locations[locations.Count - 1];
+                /*
+                for (int i = 0; i < locations.Count; i++)
+                {
+                    if (location == IntVec3.Invalid || num > (predator.Position - locations[i]).LengthHorizontal)
+                    {
+                        location = locations[i];
+                        num = (predator.Position - locations[i]).LengthHorizontal;
+                    }
+                }
+                */
             }
 
             return location;
@@ -478,6 +491,7 @@ namespace Zombiefied
             {
                 foreach (Map map in Find.Maps)
                 {
+                    //List<Thing> list = map.listerThings.ThingsInGroup(ThingRequestGroup.Corpse);
                     List<Thing> list = map.listerThings.AllThings;
                     if (list != null)
                     {

--- a/Source/ZombiefiedMod.cs
+++ b/Source/ZombiefiedMod.cs
@@ -54,10 +54,14 @@ namespace Zombiefied
                     zFaction = faction;
                 }
             }
+            //Faction.OfMechanoids.TrySetNotHostileTo(zFaction);
             zFaction.RelationWith(Faction.OfMechanoids).kind = FactionRelationKind.Ally;
+            //zFaction.RelationWith(Faction.OfMechanoids).goodwill = 100;
             zFaction.RelationWith(Faction.OfMechanoids).baseGoodwill = 100;
             Faction.OfMechanoids.RelationWith(zFaction).kind = FactionRelationKind.Ally;
             Faction.OfMechanoids.RelationWith(zFaction).baseGoodwill = 100;
+            //zFaction.TrySetNotHostileTo(Faction.OfMechanoids);
+            //zFaction.TryMakeInitialRelationsWith(Faction.OfMechanoids);
 
             int zKilled = 0;
             int zCount = 0;
@@ -84,7 +88,35 @@ namespace Zombiefied
                 }
             }
 
+            /*
+            foreach (RimWorld.Planet.Site site in Find.World.worldObjects.Sites)
+            {
+                bool broken = false;
+                if (site != null)
+                {
+                    if (site.core == null || site.core.def == null || site.core.def.Worker == null || site.core.def.workerClass == null)
+                    {
+                        broken = true;
+                    }
+
+                    foreach (RimWorld.Planet.SitePart part in site.parts)
+                    {
+                        if(part.def == null || part.def.Worker == null || part.def.workerClass == null)
+                        {
+                            broken = true;
+                        }
+                    }
+                }
+                if(broken)
+                {
+                    base.Logger.Message("found a broken site.");
+                    //handle broken site here
+                }
+            }
+            */
+
             debugRemoveZombies.Value = false;
+            //base.Logger.Message("found " + zCount + " Zombies. " + zWrongFactionCount + " of them were repaired.", new object[0]);
         }
 
         public override void DefsLoaded()
@@ -95,6 +127,8 @@ namespace Zombiefied
             };
             headlineZombieOptions = base.Settings.GetHandle<bool>("headlineZombies", "\nZombie settings:", "Zombie settings", false, null, null);
             headlineZombieOptions.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
+            //headlineZombieOptions.CustomDrawerHeight = 37f;
+
             disableAnimalZombies = base.Settings.GetHandle<bool>("disableAnimalZombies", "       Disable animal zombies", "Animals will not resurrect and no animal zombies will wander in.", false, null, null);
             disableZombiesAttackingAnimals = base.Settings.GetHandle<bool>("disableZombiesAttackingAnimals", "       Disable zombies attacking animals", "Zombies will ignore animals.", false, null, null);
             zombieSpeedMultiplier = base.Settings.GetHandle<float>("ZombieSpeedMultiplier", "       Zombie speed multiplier [RESTART]", "Zombie speed (in comparison to healthy) will be multiplied by this value.\n(0.03 -> Slowest, 3 -> Fastest)\n(Requires restart to work)", 0.57f, null, null);
@@ -111,6 +145,9 @@ namespace Zombiefied
 
             headlineZombieAmount = base.Settings.GetHandle<bool>("headlineAmounts", "\nAmount settings:", "Amount settings", false, null, null);
             headlineZombieAmount.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
+            //headlineZombieAmount.CustomDrawerHeight = 37f;
+
+            //easyMode = base.Settings.GetHandle<bool>("EasyMode", "Easy mode", "Keep in mind that you are not meant to kill all zombies at all times and losing is part of the game.", false, null, null);
             zombieAmountSoftCap = base.Settings.GetHandle<int>("ZombieAmountSoftCap", "       Zombie amount soft cap", "The expected amount of zombies per map.", 133, null, null);
 
             zombieRaidAmountMultiplier = base.Settings.GetHandle<float>("ZombieRaidAmountMultiplier", "       Zombie raid size multiplier", "Zombie raid size will be multiplied by this value.\n(0.1 -> Easiest, 7 -> Hardest)", 1f, null, null);
@@ -118,24 +155,39 @@ namespace Zombiefied
 
             headlineNotifications = base.Settings.GetHandle<bool>("headlineNotifications", "\nNotification settings:", "Notification settings", false, null, null);
             headlineNotifications.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
+            //headlineNotifications.CustomDrawerHeight = 37f;
 
             zombieRaidNotifications = base.Settings.GetHandle<bool>("ZombieRaidNotifications", "       Zombie raid notifications", "Get a notification when zombies wander in.", true, null, null);
             zombieResurrectNotifications = base.Settings.GetHandle<bool>("ZombieResurrectNotifications", "       Zombie resurrect notifications", "Get a notification when a zombie resurrects.", false, null, null);
 
             headlineDebug = base.Settings.GetHandle<bool>("headlineDebug", "\nDebug settings:", "Debug settings", false, null, null);
             headlineDebug.CustomDrawer = new SettingHandle.DrawCustomControl(predicate);
+            //headlineDebug.CustomDrawerHeight = 37f;
 
             debugRemoveZombies = base.Settings.GetHandle<bool>("DebugRemoveZombies", "       Debug remove zombies [RELOAD]", "Enable this and reload to remove all zombies on next load.", false, null, null);
+
+            /*
+            zombieSoundReactionTimeInHours.CustomDrawerHeight = 77;
+            zombieAmountSoftCap.CustomDrawerHeight = 77;
+            zombieRaidAmountMultiplier.CustomDrawerHeight = 77;
+            zombieRaidFrequencyMultiplier.CustomDrawerHeight = 77;
+            zombieRaidNotifications.CustomDrawerHeight = 77;
+            zombieResurrectNotifications.CustomDrawerHeight = 77;
+            debugRemoveZombies.CustomDrawerHeight = 77;
+            */
 
             InitializeCustom();
         }
 
         internal static SettingHandle<bool> headlineZombieOptions;
+        //
         internal static SettingHandle<bool> disableAnimalZombies;
         internal static SettingHandle<bool> disableZombiesAttackingAnimals;
         internal static SettingHandle<float> zombieSpeedMultiplier;
         internal static SettingHandle<int> zombieSoundReactionTimeInHours;
+
         internal static SettingHandle<bool> headlineZombieAmount;
+        //
         internal static SettingHandle<float> zombieRaidFrequencyMultiplier;
         public static float ZombieRaidFrequencyMultiplier
         {
@@ -169,10 +221,14 @@ namespace Zombiefied
             }
         }
         internal static SettingHandle<int> zombieAmountSoftCap;
+
         internal static SettingHandle<bool> headlineNotifications;
+        //
         internal static SettingHandle<bool> zombieRaidNotifications;
         internal static SettingHandle<bool> zombieResurrectNotifications;
+
         internal static SettingHandle<bool> headlineDebug;
+        //
         internal static SettingHandle<bool> debugRemoveZombies;
 
         public override void Tick(int currentTick)
@@ -189,7 +245,10 @@ namespace Zombiefied
             {
                 num = 0.7f;
             }
+            //if (easyMode)
+            //{
             num /= ZombieRaidFrequencyMultiplier;
+            //}
             if ((double)num < 0.17f)
             {
                 num = 0.17f;
@@ -204,7 +263,10 @@ namespace Zombiefied
         private int GenerateTicksUntilNextRaid()
         {
             float challengeModifier = this.GetChallengeModifier();
+            //int num = UnityEngine.Random.Range((int)((float)ZombiesDefOf.ZombiesSettings.MinRaidTicksBase * challengeModifier), (int)((float)ZombiesDefOf.ZombiesSettings.MaxRaidTicksBase * challengeModifier));
             int num = Rand.RangeSeeded((int)((float)7777 * challengeModifier), (int)((float)280000 * challengeModifier), Find.TickManager.TicksAbs + Find.World.ConstantRandSeed);
+            //if (first && num < ZombiesDefOf.ZombiesSettings.MinTicksBeforeFirstRaid)
+            //base.Logger.Message("next zombieraid in " + num + " ticks.", new object[0]);
             return num;
         }
 
@@ -216,6 +278,9 @@ namespace Zombiefied
                 if (this._ticksUntilNextZombieRaid[currentMapIndex] <= 0)
                 {
                     this._ticksUntilNextZombieRaid[currentMapIndex] = this.GenerateTicksUntilNextRaid();
+
+                    //base.Logger.Message("setting up zombieraid for map " + currentMapIndex + ".", new object[0]);
+
                     if (currentMapIndex < zombieAmountsPerMap.Count && zombieAmountsPerMap[currentMapIndex] < zombieAmountSoftCap)
                     {
                         IncidentParms incidentParms = new IncidentParms
@@ -232,6 +297,11 @@ namespace Zombiefied
                         {
                             IncidentDef.Named("ZombiePack").Worker.TryExecute(incidentParms);
                         }
+                        //base.Logger.Message("Zombieraid started on map " + currentMapIndex + ".", new object[0]);
+                    }
+                    else
+                    {
+                        //base.Logger.Message("Zombieraid failed on map " + currentMapIndex + " because map invalid or more zombies are already on the map than cap allows.", new object[0]);
                     }
                 }
             }
@@ -254,7 +324,7 @@ namespace Zombiefied
                 {
                     if (noisyLocationsPerMap[m].Count > 0)
                     {
-                        if (Find.TickManager.TicksGame - noisyLocationTicksPerMap[m].Peek() > zombieSoundReactionTimeInHours * 2500)
+                        if (Find.TickManager.TicksGame - noisyLocationTicksPerMap[m].Peek() > zombieSoundReactionTimeInHours * 2500) //7777)
                         {
                             noisyLocationsPerMap[m].Dequeue();
                             noisyLocationTicksPerMap[m].Dequeue();
@@ -321,6 +391,9 @@ namespace Zombiefied
                                                 bestLocation = pawn2.Position;
                                                 bestLocationTicks = pawn2.LastAttackTargetTick;
                                             }
+
+                                            //noisyLocationsPerMap[m].Enqueue(pawn2.Position);
+                                            //noisyLocationTicksPerMap[m].Enqueue(pawn2.LastAttackTargetTick);
                                         }
                                         shotsFiredPerPawn[key] = pawn2.records.GetAsInt(RecordDefOf.ShotsFired);
                                     }
@@ -444,7 +517,9 @@ namespace Zombiefied
 
         public Pawn ReanimateDeath(Corpse corpse)
         {
+            //base.Logger.Message(corpse.InnerPawn.story.HeadGraphicPath, new object[0]);
             Pawn_Zombiefied zombiePawn = ZombiefiedMod.GenerateZombieFromSource(corpse.InnerPawn);
+            //Pawn zombiePawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Alphabeaver, Faction.OfPlayer);
             IntVec3 position = corpse.Position;
             Building building = StoreUtility.StoringThing(corpse) as Building;
             Building_Storage building_Storage = (Building_Storage)building;
@@ -456,6 +531,12 @@ namespace Zombiefied
 
             Thing t = GenSpawn.Spawn(zombiePawn, position, corpse.Map);
             corpse.TakeDamage(new DamageInfo(DamageDefOf.Deterioration, 77777f));
+
+            //for(int i = 0; i < Find.BattleLog.Battles.Count; i++)
+            //{
+            //InteractionCardUtility_Zombiefied.DrawInteractionsLog(corpse.InnerPawn, t, Find.BattleLog.Battles[i].Entries, 50);
+            //}
+            //InteractionCardUtility_Zombiefied.DrawInteractionsLog(corpse.InnerPawn, t, Find.BattleLog.RawEntries, 50);
 
             if (zombieResurrectNotifications && t != null)
             {
@@ -505,6 +586,7 @@ namespace Zombiefied
 
             pawn.records = sourcePawn.records;
             pawn.gender = sourcePawn.gender;
+            //pawn.needs.SetInitialLevels();
 
             if (sourcePawn.Faction != null && sourcePawn.Faction.IsPlayer)
             {
@@ -599,6 +681,8 @@ namespace Zombiefied
                 }
             }
             ThingRequestGroupUtility.StoreInRegion(ThingRequestGroup.Corpse);
+            //Pawn pawntest;
+            //pawntest.Map.listerThings.Add
 
             bool first = true;
             List<PawnKindDef> listPawnKindDef = DefDatabase<PawnKindDef>.AllDefsListForReading;
@@ -614,16 +698,17 @@ namespace Zombiefied
                         if(sourcePawnKindDef.weaponTags[t].Contains("Melee") && sourcePawnKindDef.weaponTags[t].Contains("Neolithic"))
                         {
                             sourcePawnKindDef.weaponTags[t] = "NeolithicRangedChief";
+                            //sourcePawnKindDef.
                         }
                         log += sourcePawnKindDef.weaponTags[t] + " ";
                     }
+                    //base.Logger.Message(log);
                 }
 
 
                 if (sourcePawnKindDef.defName == null || (sourcePawnKindDef.defName.Length >= 6 && sourcePawnKindDef.defName.Substring(0, 6) == "Zombie") || DefDatabase<PawnKindDef>.GetNamed("Zombie" + sourcePawnKindDef.defName, false) != null)
                 {
-                    // Nothing
-                    // TODO: Refactor this to just use the ! operator or something
+                    //Nothing
                 }
                 else
                 {
@@ -658,7 +743,12 @@ namespace Zombiefied
 
                                 newThingDef.drawGUIOverlay = true;
 
+                                //int e = (int)(sourcePawnKindDef.race.shortHash);
+                                //ushort f = (ushort)(e + 7);
+                                //newThingDef.shortHash = f;
                                 InjectedDefHasher.GiveShortHashToDef(newThingDef, typeof(ThingDef));
+
+                                //reached
 
                                 Predicate<StatModifier> findMoveSpeed = delegate (StatModifier statMod)
                                 {
@@ -731,6 +821,9 @@ namespace Zombiefied
                                     }
                                     return false;
                                 };
+
+                                //reached
+
                                 newThingDef.statBases = new List<StatModifier>();
 
                                 StatModifier newStat = new StatModifier();
@@ -766,6 +859,18 @@ namespace Zombiefied
                                     newThingDef.statBases.Add(newStat);
                                 }
 
+                                /*
+                                StatModifier statHeat = sourcePawnKindDef.race.statBases.Find(findArmorRating_Heat);
+                                if (statHeat != null)
+                                {
+                                    newStat = new StatModifier();
+                                    newStat.stat = StatDefOf.ArmorRating_Heat;
+                                    newStat.value = statHeat.value;
+                                    newThingDef.statBases.Add(newStat);
+                                }
+                                */
+
+
                                 newStat = new StatModifier();
                                 newStat.stat = StatDefOf.PsychicSensitivity;
                                 newStat.value = 0f;
@@ -781,17 +886,19 @@ namespace Zombiefied
                                 newStat.value = sourcePawnKindDef.race.statBases.Find(findMoveSpeed).value * zombieSpeedMultiplier;
                                 newThingDef.statBases.Add(newStat);
 
-                                // Setup standard zombie
+                                //setup standard zombie
                                 if(first)
                                 {
                                     zombieThingDef.statBases.Find(findMoveSpeed).value = 4.6f * zombieSpeedMultiplier;
                                 }
+                                //setup standard zombie
 
                                 //CE SUPPORT
                                 StatModifier statCEDodge;
                                 statCEDodge = sourcePawnKindDef.race.statBases.Find(findMeleeDodgeChance);
                                 if(statCEDodge != null)
                                 {
+                                    //Log.Message("found CE for " + sourcePawnKindDef.defName);
                                     newThingDef.statBases.Add(statCEDodge);
                                     if (first)
                                     {
@@ -818,10 +925,12 @@ namespace Zombiefied
                                         zombieThingDef.statBases.Add(statCEParry);
                                     }
                                 }
-                                // CE SUPPORT
+                                //CE SUPPORT
                                 first = false;
 
                                 newThingDef.BaseMarketValue = sourcePawnKindDef.race.BaseMarketValue;
+
+                                //reached
 
                                 newThingDef.tools = new List<Tool>();
                                 int iTool = -1;
@@ -863,6 +972,8 @@ namespace Zombiefied
                                 newThingDef.race.meatColor = color;
 
                                 newThingDef.race.leatherDef = zombieThingDef.race.leatherDef;
+                                //newThingDef.race.leatherColor = color;
+                                //newThingDef.race.leatherLabel = "zombie" + sourcePawnKindDef.race.race.leatherLabel;
                                 newThingDef.race.useLeatherFrom = zombieThingDef;
                                 newThingDef.race.useMeatFrom = zombieThingDef;
 
@@ -885,6 +996,7 @@ namespace Zombiefied
                                 newThingDef.race.foodType = zombieThingDef.race.foodType;
                                 newThingDef.race.predator = zombieThingDef.race.predator;
                                 newThingDef.race.makesFootprints = sourcePawnKindDef.race.race.makesFootprints;
+                                //newThingDef.race.leatherInsulation = sourcePawnKindDef.race.race.leatherInsulation;
 
                                 newThingDef.race.lifeStageAges = new List<LifeStageAge>();
                                 for (int l = 0; l < sourcePawnKindDef.race.race.lifeStageAges.Count; l++)
@@ -914,20 +1026,32 @@ namespace Zombiefied
                                 newThingDef.ResolveReferences();
                             }
 
+                            //not reached
 
                             PawnKindDef newKindDef = new PawnKindDef();
+                            //newKindDef = PawnKindDef.Named("Zombie");
 
                             newKindDef.defName = "Zombie" + sourcePawnKindDef.defName;
                             newKindDef.label = "zombie " + sourcePawnKindDef.label;
                             newKindDef.race = newThingDef;
+                            //newKindDef.race = ThingDef.Named("Zombie");
 
                             newKindDef.defaultFactionType = PawnKindDef.Named("Zombie").defaultFactionType;
-                            newKindDef.combatPower = 0;
+                            newKindDef.combatPower = 0;// sourcePawnKindDef.combatPower / 2;
                             newKindDef.canArriveManhunter = false;
+
+                            //int s = (int)(sourcePawnKindDef.shortHash);
+                            //ushort z = (ushort)(s + 7);
+                            //newKindDef.shortHash = z;
                             InjectedDefHasher.GiveShortHashToDef(newKindDef, typeof(PawnKindDef));
+
+                            //base.Logger.Message((newKindDef.RaceProps != null) + "");
+
+                            //newKindDef.lifeStages = PawnKindDef.Named("Zombie").lifeStages;
 
                             newKindDef.lifeStages = new List<PawnKindLifeStage>();
 
+                            //newKindDef.lifeStages = sourcePawnKindDef.lifeStages;
                             for (int j = 0; j < sourcePawnKindDef.lifeStages.Count; j++)
                             {
                                 newKindDef.lifeStages.Add(new PawnKindLifeStage());
@@ -958,7 +1082,12 @@ namespace Zombiefied
                                     newKindDef.lifeStages[j].dessicatedBodyGraphicData = new GraphicData();
                                     newKindDef.lifeStages[j].dessicatedBodyGraphicData.CopyFrom(sourcePawnKindDef.lifeStages[j].dessicatedBodyGraphicData);
                                 }
+
+                                //newKindDef.lifeStages[j].ResolveReferences();
+
+                                //newKindDef.lifeStages.Add(n);
                             }
+                            //base.Logger.Message((newKindDef.RaceProps != null) + "");
                             if (newKindDef != null && newThingDef != null && newKindDef.RaceProps != null)
                             {
                                 DefDatabase<PawnKindDef>.Add(newKindDef);


### PR DESCRIPTION
Deals with various compiler warnings. Potentially with some _opinions_

**Warning related**
- Handles unreachable code, via outright removing them
- Handles deprecated logger calls
  - Removed the Boolean argument to them. I'm unsure of what that did before, but apparently it's deprecated.
  - Changed the structure of some logging calls. There's probably a nicer way to do it than a simple concat. Bit rusty with C# at the moment to know if there's a nice C-Style way to format strings, but logging a lot of data is weird no matter how it's written. Hm.
- Handles Obsolete `CellRect.CenteredOn`... iterator usage.
  - Simply doing a foreach on the CellRect and looping through cells.
  - Noticed in doing this that in one loop the iterated cell isn't being used and it seems to be just counting up cells that can support things? Not sure what that's about.
- Removed unused variables
  
**Non-Warning-Related**
- Removes commented out code.
  - Definitely opinionated here. I feel any old code can be pulled back up via git history if it's really needed. Most of the time it's not. Up for discussion if this is something wanted on the main branch. 
- Removes Token comments.
  - Probably not super useful if the decompilation changes the reference, which I imagine would happen any time the game updates, right? I could be wrong on this, but I also don't know the value in keeping them. Could very well be wrong on this one.