### PR TITLE
Ensure only bites cause infections.

### DIFF
--- a/Source/DamageWorker_ZombieBite.cs
+++ b/Source/DamageWorker_ZombieBite.cs
@@ -14,41 +14,41 @@ namespace Zombiefied
     public class DamageWorker_ZombieBite : DamageWorker_AddInjury
     {
         // Token: 0x06004219 RID: 16921 RVA: 0x001E310A File Offset: 0x001E150A
-        protected override BodyPartRecord ChooseHitPart(DamageInfo dinfo, Pawn pawn)
+        protected override BodyPartRecord ChooseHitPart(DamageInfo damageInfo, Pawn pawn)
         {
-            return GetRandomNotMissingNotTorsoPart(dinfo, pawn, 0);
+            String[] forbiddenBodyParts = { "TORSO", "BODY", "NECK", "HEAD" };
+            BodyPartRecord bodyPart = new BodyPartRecord();
+            for (int tries = 7; tries > 0; tries--)
+            {
+                bodyPart = pawn.health.hediffSet.GetRandomNotMissingPart(damageInfo.Def, damageInfo.Height, BodyPartDepth.Outside);
+                String partName = bodyPart.def.defName.ToUpper();
+                if (pawn.health.Downed || !forbiddenBodyParts.Contains(partName)) break;
+            }
+            return bodyPart;
         }
 
-        private BodyPartRecord GetRandomNotMissingNotTorsoPart(DamageInfo dinfo, Pawn pawn, int i)
+        private bool IsInfectable(BodyPartRecord bodyPart, HediffSet hediffSet)
         {
-            BodyPartRecord temp = pawn.health.hediffSet.GetRandomNotMissingPart(dinfo.Def, dinfo.Height, BodyPartDepth.Outside);
-
-            if(i > 7 || pawn.health.Downed || (!temp.def.defName.ToUpper().Contains("TORSO") && !temp.def.defName.ToUpper().Contains("BODY") && !temp.def.defName.ToUpper().Contains("NECK") && !temp.def.defName.ToUpper().Contains("HEAD")))
-            {
-                return temp;
-            }
-            return GetRandomNotMissingNotTorsoPart(dinfo, pawn, ++i);
+            BodyPartDef bodyPartDef = bodyPart.def;
+            if (hediffSet.PartIsMissing(bodyPart)) return false;
+            return (!bodyPartDef.IsSolid(bodyPart, hediffSet.hediffs) || bodyPartDef.IsSkinCovered(bodyPart, hediffSet));
         }
 
         // Token: 0x0600421A RID: 16922 RVA: 0x001E312B File Offset: 0x001E152B
         protected override void ApplySpecialEffectsToPart(Pawn pawn, float totalDamage, DamageInfo dinfo, DamageWorker.DamageResult result)
         {
-            bool partSkinnedOrNotSolid = (!dinfo.HitPart.def.IsSolid(dinfo.HitPart, pawn.health.hediffSet.hediffs) || dinfo.HitPart.def.IsSkinCovered(dinfo.HitPart, pawn.health.hediffSet));
-
             base.FinalizeAndAddInjury(pawn, totalDamage, dinfo, result);
-
-            if (!pawn.health.hediffSet.PartIsMissing(dinfo.HitPart))
+            // Only infect on bites! Haven't seen an example of a Zombie scratch...
+            if (dinfo.Def.defName != "ZombieBite") return;
+            // Can't infect a robot, or other non-fleshy things
+            if (!pawn.def.race.IsFlesh) return;
+            // Try infecting the hit part first, then the parent of it.
+            foreach (BodyPartRecord bodyPart in new BodyPartRecord[] { dinfo.HitPart, dinfo.HitPart.parent })
             {
-                if(pawn.def.race.IsFlesh && partSkinnedOrNotSolid)
+                if (IsInfectable(bodyPart, pawn.health.hediffSet))
                 {
-                    pawn.health.AddHediff(HediffDef.Named("ZombieWoundInfection"), dinfo.HitPart, null);
-                }              
-            }
-            else if (!pawn.health.hediffSet.PartIsMissing(dinfo.HitPart.parent) && partSkinnedOrNotSolid)
-            {
-                if (pawn.def.race.IsFlesh && (!dinfo.HitPart.parent.def.IsSolid(dinfo.HitPart.parent, pawn.health.hediffSet.hediffs) || dinfo.HitPart.parent.def.IsSkinCovered(dinfo.HitPart.parent, pawn.health.hediffSet)))
-                {
-                    pawn.health.AddHediff(HediffDef.Named("ZombieWoundInfection"), dinfo.HitPart.parent, null);
+                    pawn.health.AddHediff(HediffDef.Named("ZombieWoundInfection"), bodyPart, null);
+                    break;
                 }
             }
         }

--- a/Source/DamageWorker_ZombieBite.cs
+++ b/Source/DamageWorker_ZombieBite.cs
@@ -35,15 +35,15 @@ namespace Zombiefied
         }
 
         // Token: 0x0600421A RID: 16922 RVA: 0x001E312B File Offset: 0x001E152B
-        protected override void ApplySpecialEffectsToPart(Pawn pawn, float totalDamage, DamageInfo dinfo, DamageWorker.DamageResult result)
+        protected override void ApplySpecialEffectsToPart(Pawn pawn, float totalDamage, DamageInfo damageInfo, DamageWorker.DamageResult result)
         {
-            base.FinalizeAndAddInjury(pawn, totalDamage, dinfo, result);
+            base.FinalizeAndAddInjury(pawn, totalDamage, damageInfo, result);
             // Only infect on bites! Haven't seen an example of a Zombie scratch...
-            if (dinfo.Def.defName != "ZombieBite") return;
+            if (damageInfo.Def.defName != "ZombieBite") return;
             // Can't infect a robot, or other non-fleshy things
             if (!pawn.def.race.IsFlesh) return;
             // Try infecting the hit part first, then the parent of it.
-            foreach (BodyPartRecord bodyPart in new BodyPartRecord[] { dinfo.HitPart, dinfo.HitPart.parent })
+            foreach (BodyPartRecord bodyPart in new BodyPartRecord[] { damageInfo.HitPart, damageInfo.HitPart.parent })
             {
                 if (IsInfectable(bodyPart, pawn.health.hediffSet))
                 {

--- a/Source/DamageWorker_ZombieBite.cs
+++ b/Source/DamageWorker_ZombieBite.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using HugsLib;
-using HugsLib.Settings;
-using HugsLib.Utils;
-using RimWorld;
-using UnityEngine;
 using Verse;
 
 namespace Zombiefied


### PR DESCRIPTION
Solves Issue #2 

Did a bit of messing around with the code here to get a better understanding of how it works.

- Removed recursion in `GetRandomNotMissingNotTorsoPart`, and in doing so, removed the need for a whole seperate function for it.
- Added a function for figuring out if a body part is infectable or not.
- Used a loop instead of a couple conditionals for moving up parent body parts.
  - In theory, we could keep going up the chain but I'm not sure how much it'd matter, just once is probably fine.
- Renames some `dinfo` variables to `damageInfo`, for readability sake.
- Removes unused imports